### PR TITLE
chore(ci): add prettier, turbo, and local commit hooks

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# One-shot repository-wide Prettier reformat commit.
+5737d9f4ff9b3ae291ea9caad3197c5eaf9f5b6e

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
 ## Summary
 
-- 
+-
 
 ## Changes
 
-- 
+-
 
 ## Test plan
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,5 +1,10 @@
 name: setup-patternmesh
 description: Set up Node, pnpm, and install dependencies
+inputs:
+  node-version:
+    description: Node.js version to install
+    required: false
+    default: "20"
 runs:
   using: composite
   steps:
@@ -7,7 +12,7 @@ runs:
 
     - uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: ${{ inputs.node-version }}
         cache: pnpm
 
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,33 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [18, 20, 22]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Cache Turbo
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ matrix.node }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-${{ matrix.node }}-
+            turbo-${{ runner.os }}-
 
       - name: Start DynamoDB Local
         run: docker compose up -d dynamodb-local
@@ -37,16 +56,24 @@ jobs:
           exit 1
 
       - name: Build
+        timeout-minutes: 10
         run: pnpm build
 
       - name: Generate API docs
         run: pnpm docs:api
 
       - name: Test
+        timeout-minutes: 15
         run: pnpm test
+
+      - name: Format check
+        run: pnpm format:check
 
       - name: Lint
         run: pnpm lint
+
+      - name: Syncpack lint
+        run: pnpm syncpack lint
 
       - name: Typecheck
         run: pnpm typecheck
@@ -59,3 +86,12 @@ jobs:
 
       - name: Smoke test tarballs
         run: pnpm smoke:pack
+
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
   dependency-review:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - uses: actions/dependency-review-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,17 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
+        with:
+          node-version: 20
+
+      - name: Cache Turbo
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-release-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-release-
+            turbo-${{ runner.os }}-
 
       - name: Start DynamoDB Local
         run: docker compose up -d dynamodb-local
@@ -42,16 +53,24 @@ jobs:
           exit 1
 
       - name: Build
+        timeout-minutes: 10
         run: pnpm build
 
       - name: Generate API docs
         run: pnpm docs:api
 
       - name: Test
+        timeout-minutes: 15
         run: pnpm test
+
+      - name: Format check
+        run: pnpm format:check
 
       - name: Lint
         run: pnpm lint
+
+      - name: Syncpack lint
+        run: pnpm syncpack lint
 
       - name: Typecheck
         run: pnpm typecheck

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ dist
 coverage
 docs/api
 site
+.turbo
 .env
 .DS_Store

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+pnpm exec commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+pnpm lint-staged

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,11 @@
+node_modules
+dist
+site
+docs/api
+coverage
+pnpm-lock.yaml
+CHANGELOG.md
+packages/*/CHANGELOG.md
+.changeset/*.md
+.pnpm-store
+.cursor

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,23 +17,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
+- Focusing on what is best not just for us as individuals, but for the
   overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
+- The use of sexualized language or imagery, and sexual attention or
   advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
   address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ### Enforcement Responsibilities

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Tests are automatically skipped when `DYNAMODB_ENDPOINT` is unset.
 
 ## Repository layout
 
-```
+```text
 packages/
   core/                  # @patternmeshjs/core — modeling DSL, repositories, transactions
   adapter-aws-sdk-v3/    # @patternmeshjs/aws-sdk-v3 — DocumentClient adapter
@@ -81,6 +81,20 @@ TypeDoc output plus rendered markdown from `README.md`, `docs/*.md`, and
 `docs/guides/*.md`. The `pages.yml` workflow publishes this on every push to
 `main`.
 
+## Formatting
+
+This repo uses Prettier for formatting and ESLint for correctness rules.
+
+- format everything: `pnpm format`
+- check formatting only: `pnpm format:check`
+
+After pulling the one-shot formatting commit, configure git blame once so the
+mass reformat is hidden:
+
+```bash
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
 ## Local CI with act (optional)
 
 [act](https://github.com/nektos/act) runs our GitHub Actions workflows
@@ -95,7 +109,7 @@ act push -W .github/workflows/ci.yml --job test
 Host-specific flags belong in your personal `~/.actrc`, not the repo file.
 On an Apple Silicon Mac with Docker Desktop, the minimal override is:
 
-```
+```text
 --container-architecture linux/amd64
 ```
 
@@ -132,18 +146,25 @@ Caveats:
 4. **Add or update tests.** New behavior needs unit tests; integration tests
    where an adapter round-trip matters.
 5. **Run the full check locally**:
+
    ```bash
    pnpm build
    pnpm test
+   pnpm format:check
    pnpm lint
+   pnpm syncpack lint
    pnpm typecheck
    ```
+
 6. **Add a changeset** describing your change (required for any release):
+
    ```bash
    pnpm changeset
    ```
+
    Pick the affected packages and the appropriate bump type (`patch`,
    `minor`, or `major`). Commit the generated file alongside your change.
+
 7. **Open a pull request** against `main`. Fill in the PR template.
 
 ### Changeset guidance
@@ -165,26 +186,51 @@ behavior change.
 
 **Bump type mapping for this repo:**
 
-| Bump    | Use when                                                                            |
-| ------- | ----------------------------------------------------------------------------------- |
-| `patch` | bug fix with no API surface change; more permissive types; improved error messages  |
-| `minor` | new exported symbol; additive type widening; new entity/relation/recipe feature     |
-| `major` | removed or renamed export; narrowed types; changed runtime semantics of existing API|
+| Bump    | Use when                                                                             |
+| ------- | ------------------------------------------------------------------------------------ |
+| `patch` | bug fix with no API surface change; more permissive types; improved error messages   |
+| `minor` | new exported symbol; additive type widening; new entity/relation/recipe feature      |
+| `major` | removed or renamed export; narrowed types; changed runtime semantics of existing API |
 
 While we are on `0.x`, breaking changes are allowed in minor bumps per SemVer
 convention, but we still tag them as `major` in changesets so the CHANGELOG
 flags them clearly. Once we cut `1.0.0`, `major` will track SemVer strictly.
 
+## Git hooks
+
+Hooks are installed automatically by `pnpm install` via the root `prepare`
+script.
+
+- `pre-commit`: runs `lint-staged`, which applies `eslint --fix` and
+  `prettier --write` to staged files only.
+- `commit-msg`: runs `commitlint` with Conventional Commit rules.
+
+Bypass hooks only for emergencies:
+
+- `HUSKY=0 git commit -m "..."` (single command bypass)
+- `git commit --no-verify` (git-level bypass)
+
 ## Commit messages
 
-We do not mandate a strict convention, but clear, imperative subjects help
-during release. For example:
+Commit messages are validated with Conventional Commits. Use one of these
+types:
 
+- `feat`, `fix`, `docs`, `style`, `refactor`, `perf`
+- `test`, `build`, `ci`, `chore`, `revert`
+
+Examples:
+
+```text
+feat(core): add typed query cursor helper
+fix(streams): handle missing old image on ttl remove
+chore(ci): add format check and turbo cache
 ```
-Reject reserved attribute names at defineEntity
-Add isTtlRemove helper to @patternmeshjs/streams
-Fix batchGet reconciliation to be O(n)
-```
+
+Breaking changes can be marked as `feat!:` (or another type with `!`) and
+described in a `BREAKING CHANGE:` footer.
+
+Conventional commits keep history consistent, but package versioning is still
+driven by changesets (`.changeset/*.md`), not commit subjects.
 
 ## Code style
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ explainable compiled operations.
 
 ## Packages
 
-| Package | Purpose |
-| --- | --- |
-| [`@patternmeshjs/core`](packages/core/README.md) | schema DSL, repositories, access patterns, transactions, relations |
-| [`@patternmeshjs/aws-sdk-v3`](packages/adapter-aws-sdk-v3/README.md) | AWS DocumentClient adapter |
-| [`@patternmeshjs/streams`](packages/streams/README.md) | typed stream decoding and routing |
+| Package                                                              | Purpose                                                            |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| [`@patternmeshjs/core`](packages/core/README.md)                     | schema DSL, repositories, access patterns, transactions, relations |
+| [`@patternmeshjs/aws-sdk-v3`](packages/adapter-aws-sdk-v3/README.md) | AWS DocumentClient adapter                                         |
+| [`@patternmeshjs/streams`](packages/streams/README.md)               | typed stream decoding and routing                                  |
 
 ## Install
 
@@ -125,9 +125,7 @@ db.User.explain.get({ userId: "usr_1" });
 ### Updates and conditions
 
 ```ts
-const updated = await db.User.update({ userId: "usr_1" })
-  .set({ name: "Ada Byron" })
-  .go();
+const updated = await db.User.update({ userId: "usr_1" }).set({ name: "Ada Byron" }).go();
 ```
 
 ### Transactions

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,9 +5,9 @@
 We provide security fixes for the latest release line only.
 
 | Version | Supported |
-| --- | --- |
-| 0.9.x | Yes |
-| < 0.9 | No |
+| ------- | --------- |
+| 0.9.x   | Yes       |
+| < 0.9   | No        |
 
 ## Reporting a vulnerability
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,8 @@
+/** @type {import("@commitlint/types").UserConfig} */
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "body-max-line-length": [1, "always", 100],
+    "footer-max-line-length": [1, "always", 100],
+  },
+};

--- a/docs/guides/complex-attributes.md
+++ b/docs/guides/complex-attributes.md
@@ -159,13 +159,13 @@ cycles) throw `ValidationError`.
 
 ## Embed vs child items: a quick decision guide
 
-| Signal | Embed | Child item |
-|--------|-------|------------|
-| bounded size, always read with parent | yes | |
-| high-cardinality or unbounded | | yes |
-| independently paginated or queried | | yes |
-| high-churn with many partial writes | | yes |
-| ordered feed with cursors | | yes |
+| Signal                                | Embed | Child item |
+| ------------------------------------- | ----- | ---------- |
+| bounded size, always read with parent | yes   |            |
+| high-cardinality or unbounded         |       | yes        |
+| independently paginated or queried    |       | yes        |
+| high-churn with many partial writes   |       | yes        |
+| ordered feed with cursors             |       | yes        |
 
 For an Org / User / Membership style many-to-many, see
 [docs/guides/relations.md](./relations.md).

--- a/docs/guides/lifecycle.md
+++ b/docs/guides/lifecycle.md
@@ -184,12 +184,7 @@ await db.orchestrate.write(
       archivedAt: Math.floor(Date.now() / 1000),
     });
     o.delete("sourceDelete", User, { userId: "usr_1" });
-    o.conditionCheck(
-      "orgPresent",
-      Org,
-      { orgId: "org_1" },
-      (fields, op) => op.exists(fields.name),
-    );
+    o.conditionCheck("orgPresent", Org, { orgId: "org_1" }, (fields, op) => op.exists(fields.name));
   },
   { clientRequestToken: "custom-archive-001" },
 );

--- a/docs/guides/relations.md
+++ b/docs/guides/relations.md
@@ -21,15 +21,7 @@ A single-table `AppTable` and compiled entities for every participant:
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 import { createAwsSdkV3Adapter } from "@patternmeshjs/aws-sdk-v3";
-import {
-  connect,
-  defineTable,
-  entity,
-  enumType,
-  id,
-  key,
-  string,
-} from "@patternmeshjs/core";
+import { connect, defineTable, entity, enumType, id, key, string } from "@patternmeshjs/core";
 
 const AppTable = defineTable({
   name: "app",
@@ -149,9 +141,7 @@ await db.Org.members.add({
 const members = await db.Org.members.list({ orgId: "org_1" });
 const orgs = await db.User.orgs.listTargets({ userId: "usr_1" });
 const edge = await db.Membership.get({ orgId: "org_1", userId: "usr_1" });
-const parentOrg = edge
-  ? await db.Membership.org.get({ orgId: edge.orgId })
-  : null;
+const parentOrg = edge ? await db.Membership.org.get({ orgId: edge.orgId }) : null;
 ```
 
 ## Contracts and failure modes

--- a/docs/guides/streams-advanced.md
+++ b/docs/guides/streams-advanced.md
@@ -169,12 +169,12 @@ const decoded = decodeStreamEvent(fixture, {
 
 ## Failure-mode catalog
 
-| Condition | Error class | Thrown by |
-|-----------|-------------|-----------|
-| stream view type does not match `requiredViewType` | `StreamViewTypeError` | `decodeStreamRecord`, `decodeStreamEvent`, `handleStreamByEntity` |
-| `eventName` is not `INSERT`/`MODIFY`/`REMOVE` | `StreamDecodeError` | `decodeStreamRecord` |
-| image decoding fails (malformed attribute) | `StreamDecodeError` | `decodeStreamRecord` |
-| discriminator missing or unknown and mode is strict | `UnknownEntityError` | `decodeStreamRecord`, `decodeStreamEvent`, `handleStreamByEntity` |
+| Condition                                           | Error class           | Thrown by                                                         |
+| --------------------------------------------------- | --------------------- | ----------------------------------------------------------------- |
+| stream view type does not match `requiredViewType`  | `StreamViewTypeError` | `decodeStreamRecord`, `decodeStreamEvent`, `handleStreamByEntity` |
+| `eventName` is not `INSERT`/`MODIFY`/`REMOVE`       | `StreamDecodeError`   | `decodeStreamRecord`                                              |
+| image decoding fails (malformed attribute)          | `StreamDecodeError`   | `decodeStreamRecord`                                              |
+| discriminator missing or unknown and mode is strict | `UnknownEntityError`  | `decodeStreamRecord`, `decodeStreamEvent`, `handleStreamByEntity` |
 
 Every error extends `StreamDecodeError` and carries a `code` string for
 programmatic branching (`"STREAM_DECODE_ERROR"`, `"STREAM_VIEW_TYPE_ERROR"`,

--- a/docs/single-table-patterns.md
+++ b/docs/single-table-patterns.md
@@ -55,11 +55,11 @@ will collide at rest. Key design is a joint modeling exercise across entities.
 A common topology is **one partition key per aggregate** (e.g. organization,
 user, order) and **sort keys that sort related items together**:
 
-| Pattern | Example `sk` ideas | Typical access |
-|--------|---------------------|--------------|
-| Root + children | `ROOT`, `CHILD#<id>`, `CHILD#<id>#META` | `Query` partition with `begins_with` on `sk` for "all children" |
-| Time-ordered events | `EVENT#<iso8601>#<id>` | Range queries on time prefix |
-| Typed slots | `PROFILE`, `SETTINGS`, `SESSION#<id>` | `GetItem` for singletons; `Query` for collections |
+| Pattern             | Example `sk` ideas                      | Typical access                                                  |
+| ------------------- | --------------------------------------- | --------------------------------------------------------------- |
+| Root + children     | `ROOT`, `CHILD#<id>`, `CHILD#<id>#META` | `Query` partition with `begins_with` on `sk` for "all children" |
+| Time-ordered events | `EVENT#<iso8601>#<id>`                  | Range queries on time prefix                                    |
+| Typed slots         | `PROFILE`, `SETTINGS`, `SESSION#<id>`   | `GetItem` for singletons; `Query` for collections               |
 
 **Parent/child listing:** prefer **Query on the base table** with a bounded key
 condition (e.g. `pk = ORG#x AND begins_with(sk, "MEMBER#")`) over filtering
@@ -143,7 +143,7 @@ partition.
   partition key; you stay within one hot partition's data layout (which is
   both a feature and a capacity risk).
 
-**What LSIs do *not* do**
+**What LSIs do _not_ do**
 
 - They **cannot** introduce a **new partition key** — that is always a **GSI**
   (or a second table).
@@ -271,12 +271,12 @@ guarantees as TransactWrite).
 
 ## 12. Anti-patterns (short list)
 
-| Anti-pattern | Why |
-|--------------|-----|
-| Using **FilterExpression** as a **join** | No relational engine; you pay to read candidate items. |
-| **Unbounded `Query`** without a tight sort key | Large partitions + `begins_with` on short prefix → high RCU. |
-| **GSI sprawl** without query proof | Every index costs storage and write amplification. |
-| **Same logical entity, two key shapes** | Collision or explain-time confusion; pick one canonical key. |
+| Anti-pattern                                                  | Why                                                                                       |
+| ------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Using **FilterExpression** as a **join**                      | No relational engine; you pay to read candidate items.                                    |
+| **Unbounded `Query`** without a tight sort key                | Large partitions + `begins_with` on short prefix → high RCU.                              |
+| **GSI sprawl** without query proof                            | Every index costs storage and write amplification.                                        |
+| **Same logical entity, two key shapes**                       | Collision or explain-time confusion; pick one canonical key.                              |
 | Expecting **cross-item atomic read+write** in one Dynamo call | Use TransactWrite + application-level read strategy, or redesign for single-item updates. |
 
 ---

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,5 @@
 import eslint from "@eslint/js";
+import eslintConfigPrettier from "eslint-config-prettier";
 import tseslint from "typescript-eslint";
 
 export default [
@@ -11,8 +12,12 @@ export default [
     },
     rules: {
       "@typescript-eslint/no-non-null-assertion": "off",
-      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
       "no-undef": "off",
     },
   }),
+  eslintConfigPrettier,
 ];

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "type": "module",
   "packageManager": "pnpm@9.15.0",
   "scripts": {
-    "build": "pnpm -r run build",
-    "test": "pnpm -r run test",
+    "build": "turbo run build",
+    "test": "turbo run test",
     "lint": "eslint .",
-    "typecheck": "pnpm -r exec tsc --noEmit",
+    "typecheck": "turbo run typecheck",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "docs:api": "typedoc --options typedoc.core.json && typedoc --options typedoc.adapter.json && typedoc --options typedoc.streams.json",
     "docs:site": "node scripts/build-site.mjs --with-api",
     "publint": "publint packages/core && publint packages/adapter-aws-sdk-v3 && publint packages/streams",
@@ -15,16 +17,33 @@
     "changeset": "changeset",
     "changeset:version": "changeset version",
     "release": "changeset publish",
-    "smoke:pack": "node tests-smoke/smoke.mjs"
+    "smoke:pack": "node tests-smoke/smoke.mjs",
+    "prepare": "husky"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,mjs,cjs}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "*.{json,md,yml,yaml}": [
+      "prettier --write"
+    ]
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.2",
     "@changesets/cli": "^2.31.0",
+    "@commitlint/cli": "^20.5.0",
+    "@commitlint/config-conventional": "^20.5.0",
     "@eslint/js": "^10.0.1",
     "eslint": "^10.2.1",
+    "eslint-config-prettier": "^10.1.8",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.4.0",
     "marked": "^18.0.2",
+    "prettier": "^3.8.3",
     "publint": "^0.3.18",
     "syncpack": "^14.3.0",
+    "turbo": "^2.9.6",
     "typedoc": "^0.28.19",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.59.0"

--- a/packages/adapter-aws-sdk-v3/src/index.ts
+++ b/packages/adapter-aws-sdk-v3/src/index.ts
@@ -81,7 +81,9 @@ export function createAwsSdkV3Adapter(docClient: DynamoDBDocumentClient): Dynamo
       );
       return {
         attributes: out.Attributes as Record<string, unknown> | undefined,
-        consumedCapacity: out.ConsumedCapacity as import("@patternmeshjs/core").ConsumedCapacity | undefined,
+        consumedCapacity: out.ConsumedCapacity as
+          | import("@patternmeshjs/core").ConsumedCapacity
+          | undefined,
       };
     },
 
@@ -107,7 +109,9 @@ export function createAwsSdkV3Adapter(docClient: DynamoDBDocumentClient): Dynamo
         items: (out.Items ?? []) as Record<string, unknown>[],
         lastEvaluatedKey: out.LastEvaluatedKey as Record<string, unknown> | undefined,
         count: out.Count,
-        consumedCapacity: out.ConsumedCapacity as import("@patternmeshjs/core").ConsumedCapacity | undefined,
+        consumedCapacity: out.ConsumedCapacity as
+          | import("@patternmeshjs/core").ConsumedCapacity
+          | undefined,
       };
     },
 
@@ -131,7 +135,9 @@ export function createAwsSdkV3Adapter(docClient: DynamoDBDocumentClient): Dynamo
       return {
         items: (out.Items ?? []) as Record<string, unknown>[],
         lastEvaluatedKey: out.LastEvaluatedKey as Record<string, unknown> | undefined,
-        consumedCapacity: out.ConsumedCapacity as import("@patternmeshjs/core").ConsumedCapacity | undefined,
+        consumedCapacity: out.ConsumedCapacity as
+          | import("@patternmeshjs/core").ConsumedCapacity
+          | undefined,
       };
     },
 
@@ -166,11 +172,15 @@ export function createAwsSdkV3Adapter(docClient: DynamoDBDocumentClient): Dynamo
         }),
       );
       const items = (out.Responses?.[input.tableName] ?? []) as Record<string, unknown>[];
-      const unprocessed = out.UnprocessedKeys?.[input.tableName]?.Keys as Record<string, unknown>[] | undefined;
+      const unprocessed = out.UnprocessedKeys?.[input.tableName]?.Keys as
+        | Record<string, unknown>[]
+        | undefined;
       return {
         items,
         unprocessedKeys: unprocessed,
-        consumedCapacity: out.ConsumedCapacity as import("@patternmeshjs/core").ConsumedCapacity[] | undefined,
+        consumedCapacity: out.ConsumedCapacity as
+          | import("@patternmeshjs/core").ConsumedCapacity[]
+          | undefined,
       };
     },
 
@@ -210,7 +220,10 @@ export function createAwsSdkV3Adapter(docClient: DynamoDBDocumentClient): Dynamo
         }),
       );
       const rawUn = out.UnprocessedItems?.[tableName] as
-        | { PutRequest?: { Item?: Record<string, unknown> }; DeleteRequest?: { Key?: Record<string, unknown> } }[]
+        | {
+            PutRequest?: { Item?: Record<string, unknown> };
+            DeleteRequest?: { Key?: Record<string, unknown> };
+          }[]
         | undefined;
       const unprocessedPuts: import("@patternmeshjs/core").BatchWritePut[] = [];
       const unprocessedDeletes: import("@patternmeshjs/core").BatchWriteDelete[] = [];
@@ -225,7 +238,9 @@ export function createAwsSdkV3Adapter(docClient: DynamoDBDocumentClient): Dynamo
       return {
         unprocessedPuts,
         unprocessedDeletes,
-        consumedCapacity: out.ConsumedCapacity as import("@patternmeshjs/core").ConsumedCapacity[] | undefined,
+        consumedCapacity: out.ConsumedCapacity as
+          | import("@patternmeshjs/core").ConsumedCapacity[]
+          | undefined,
       };
     },
 
@@ -249,7 +264,9 @@ export function createAwsSdkV3Adapter(docClient: DynamoDBDocumentClient): Dynamo
       const responses = (raw.Responses ?? []).map((r) => r.Item ?? null);
       return {
         responses,
-        consumedCapacity: (out as { ConsumedCapacity?: import("@patternmeshjs/core").ConsumedCapacity[] }).ConsumedCapacity,
+        consumedCapacity: (
+          out as { ConsumedCapacity?: import("@patternmeshjs/core").ConsumedCapacity[] }
+        ).ConsumedCapacity,
       };
     },
 

--- a/packages/adapter-aws-sdk-v3/test/dynamodb-local.integration.test.ts
+++ b/packages/adapter-aws-sdk-v3/test/dynamodb-local.integration.test.ts
@@ -229,7 +229,9 @@ describe.skipIf(!hasLocal)("DynamoDB Local (AWS SDK v3 adapter)", () => {
     const byEmail = await db.User.find.byEmail({ email: "local2@example.com" });
     expect(byEmail).toMatchObject({ userId: "usr_local_2" });
 
-    const updated = await db.User.update({ userId: "usr_local_2" as never }).set({ name: "Renamed" }).go();
+    const updated = await db.User.update({ userId: "usr_local_2" as never })
+      .set({ name: "Renamed" })
+      .go();
     expect(updated).toMatchObject({ name: "Renamed", email: "local2@example.com" });
 
     const again = await db.User.get({ userId: "usr_local_2" as never });
@@ -284,9 +286,9 @@ describe.skipIf(!hasLocal)("DynamoDB Local (AWS SDK v3 adapter)", () => {
       adapter: createAwsSdkV3Adapter(doc),
       entities: { User },
     });
-    await expect(
-      db.User.find.gsiConsistentRead({ email: "any@example.com" }),
-    ).rejects.toThrow(ValidationError);
+    await expect(db.User.find.gsiConsistentRead({ email: "any@example.com" })).rejects.toThrow(
+      ValidationError,
+    );
   });
 
   it("allows ConsistentRead on LSI query and supports scan with capacity opt-in", async () => {
@@ -301,12 +303,18 @@ describe.skipIf(!hasLocal)("DynamoDB Local (AWS SDK v3 adapter)", () => {
       status: "active",
     });
 
-    const lsiPage = await db.User.find.byStatusLsi({ userId: "usr_lsi_local" as never, status: "active" });
+    const lsiPage = await db.User.find.byStatusLsi({
+      userId: "usr_lsi_local" as never,
+      status: "active",
+    });
     expect(lsiPage.items.length).toBeGreaterThanOrEqual(1);
 
     const scanned = (await db.User.find.scanUsers({
       returnConsumedCapacity: "TOTAL",
-    })) as { items: readonly Record<string, unknown>[]; consumedCapacity?: { capacityUnits?: number } };
+    })) as {
+      items: readonly Record<string, unknown>[];
+      consumedCapacity?: { capacityUnits?: number };
+    };
     expect(scanned.items.length).toBeGreaterThanOrEqual(1);
     // DynamoDB Local may omit consumed capacity even when requested.
     if (scanned.consumedCapacity) {
@@ -427,7 +435,10 @@ describe.skipIf(!hasLocal)("DynamoDB Local (AWS SDK v3 adapter)", () => {
         w.recipe("createUserSummary", (s) =>
           s
             .put("user", "User", (i) => ({ userId: i.userId, email: i.email }))
-            .put("summary", "UserSummary", (i) => ({ userId: i.userId, note: i.note ?? "created" })),
+            .put("summary", "UserSummary", (i) => ({
+              userId: i.userId,
+              note: i.note ?? "created",
+            })),
         ),
     });
     await db.recipes?.run("createUserSummary", {
@@ -443,7 +454,9 @@ describe.skipIf(!hasLocal)("DynamoDB Local (AWS SDK v3 adapter)", () => {
     expect(read?.emailLookup).toMatchObject({ userId: "usr_bundle_local" });
     const labels = await db.orchestrate?.counterSummary({
       primary: async (o) => {
-        o.conditionCheck("exists", User, { userId: "usr_bundle_local" as never }, (f, op) => op.exists(f.email));
+        o.conditionCheck("exists", User, { userId: "usr_bundle_local" as never }, (f, op) =>
+          op.exists(f.email),
+        );
       },
       summary: async (o) => {
         o.put("summary", UserSummary, { userId: "usr_bundle_local" as never, note: "updated" });

--- a/packages/adapter-aws-sdk-v3/test/index.unit.test.ts
+++ b/packages/adapter-aws-sdk-v3/test/index.unit.test.ts
@@ -46,7 +46,9 @@ describe("aws-sdk-v3 adapter transact write serialization", () => {
     const docClient = { send } as unknown as import("@aws-sdk/lib-dynamodb").DynamoDBDocumentClient;
     const adapter = createAwsSdkV3Adapter(docClient);
 
-    await expect(adapter.batchWriteItem({ puts: [], deletes: [] })).rejects.toThrow(/requires at least one put or delete/i);
+    await expect(adapter.batchWriteItem({ puts: [], deletes: [] })).rejects.toThrow(
+      /requires at least one put or delete/i,
+    );
     expect(send).not.toHaveBeenCalled();
   });
 });

--- a/packages/adapter-aws-sdk-v3/tsconfig.json
+++ b/packages/adapter-aws-sdk-v3/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist",
+    "outDir": "dist"
   },
   "include": ["src/**/*.ts"]
 }

--- a/packages/core/src/access-pattern-factory.ts
+++ b/packages/core/src/access-pattern-factory.ts
@@ -45,7 +45,11 @@ function mergeEntityFilter(
   names: Record<string, string>,
   values: Record<string, unknown>,
   kce: string,
-  extra?: { filterExpression?: string; extraNames?: Record<string, string>; extraValues?: Record<string, unknown> },
+  extra?: {
+    filterExpression?: string;
+    extraNames?: Record<string, string>;
+    extraValues?: Record<string, unknown>;
+  },
 ): {
   keyConditionExpression: string;
   expressionAttributeNames: Record<string, string>;
@@ -78,7 +82,11 @@ function mergeEntityFilterForScan(
   discriminatorValue: string,
   names: Record<string, string>,
   values: Record<string, unknown>,
-  extra?: { filterExpression?: string; extraNames?: Record<string, string>; extraValues?: Record<string, unknown> },
+  extra?: {
+    filterExpression?: string;
+    extraNames?: Record<string, string>;
+    extraValues?: Record<string, unknown>;
+  },
 ): {
   expressionAttributeNames: Record<string, string>;
   expressionAttributeValues: Record<string, unknown>;
@@ -156,20 +164,25 @@ function buildSkKeyCondition(
 ): { kceSuffix: string; names: Record<string, string>; values: Record<string, unknown> } {
   const names: Record<string, string> = {};
   const values: Record<string, unknown> = {};
-  const modes = [built.skBeginsWith !== undefined, built.skEq !== undefined, built.skBetween !== undefined].filter(
-    Boolean,
-  ).length;
+  const modes = [
+    built.skBeginsWith !== undefined,
+    built.skEq !== undefined,
+    built.skBetween !== undefined,
+  ].filter(Boolean).length;
   if (modes > 1) {
     throw new ValidationError([
       {
         path: "accessPattern",
-        message: "Specify at most one of skBeginsWith, skEq, or skBetween for the sort key condition",
+        message:
+          "Specify at most one of skBeginsWith, skEq, or skBetween for the sort key condition",
       },
     ]);
   }
   if (built.skBeginsWith !== undefined) {
     if (!skAttr) {
-      throw new ValidationError([{ path: "skBeginsWith", message: "Table or index has no sort key" }]);
+      throw new ValidationError([
+        { path: "skBeginsWith", message: "Table or index has no sort key" },
+      ]);
     }
     values[":skpre"] = built.skBeginsWith;
     return { kceSuffix: ` AND begins_with(${skAttr}, :skpre)`, names, values };
@@ -187,7 +200,9 @@ function buildSkKeyCondition(
     }
     const pair = built.skBetween;
     if (pair.length !== 2) {
-      throw new ValidationError([{ path: "skBetween", message: "skBetween must be a tuple of two string bounds" }]);
+      throw new ValidationError([
+        { path: "skBetween", message: "skBetween must be a tuple of two string bounds" },
+      ]);
     }
     values[":sklo"] = pair[0];
     values[":skhi"] = pair[1];
@@ -214,13 +229,23 @@ export function createAccessPatternFactory(table: TableDef, discriminatorValue: 
           ...built,
           limit: built.limit ?? (typeof fromInput.limit === "number" ? fromInput.limit : undefined),
           scanIndexForward:
-            built.scanIndexForward ?? (typeof fromInput.scanIndexForward === "boolean" ? fromInput.scanIndexForward : undefined),
+            built.scanIndexForward ??
+            (typeof fromInput.scanIndexForward === "boolean"
+              ? fromInput.scanIndexForward
+              : undefined),
           consistentRead:
-            built.consistentRead ?? (typeof fromInput.consistentRead === "boolean" ? fromInput.consistentRead : undefined),
-          select: built.select ?? (typeof fromInput.select === "string" ? (fromInput.select as QueryExtras<KeyParts>["select"]) : undefined),
+            built.consistentRead ??
+            (typeof fromInput.consistentRead === "boolean" ? fromInput.consistentRead : undefined),
+          select:
+            built.select ??
+            (typeof fromInput.select === "string"
+              ? (fromInput.select as QueryExtras<KeyParts>["select"])
+              : undefined),
           projectionExpression:
             built.projectionExpression ??
-            (typeof fromInput.projectionExpression === "string" ? fromInput.projectionExpression : undefined),
+            (typeof fromInput.projectionExpression === "string"
+              ? fromInput.projectionExpression
+              : undefined),
           expressionAttributeNames:
             built.expressionAttributeNames ??
             (typeof fromInput.expressionAttributeNames === "object"
@@ -231,7 +256,9 @@ export function createAccessPatternFactory(table: TableDef, discriminatorValue: 
             (typeof fromInput.returnConsumedCapacity === "string"
               ? (fromInput.returnConsumedCapacity as QueryExtras<KeyParts>["returnConsumedCapacity"])
               : undefined),
-          cursor: built.cursor ?? (typeof fromInput.cursor === "string" ? (fromInput.cursor as OpaqueCursor) : undefined),
+          cursor:
+            built.cursor ??
+            (typeof fromInput.cursor === "string" ? (fromInput.cursor as OpaqueCursor) : undefined),
         };
         const pkAttr = idx.partitionKey;
         const skAttr = idx.sortKey;
@@ -245,7 +272,10 @@ export function createAccessPatternFactory(table: TableDef, discriminatorValue: 
         Object.assign(values, skPart.values);
 
         if (builtFinal.filterExpression) {
-          if (!builtFinal.filterExpressionAttributeNames || !builtFinal.filterExpressionAttributeValues) {
+          if (
+            !builtFinal.filterExpressionAttributeNames ||
+            !builtFinal.filterExpressionAttributeValues
+          ) {
             throw new ValidationError([
               {
                 path: "filterExpression",
@@ -270,10 +300,14 @@ export function createAccessPatternFactory(table: TableDef, discriminatorValue: 
             : undefined,
         );
 
-        const projNames = builtFinal.projectionExpression ? builtFinal.expressionAttributeNames ?? {} : {};
+        const projNames = builtFinal.projectionExpression
+          ? (builtFinal.expressionAttributeNames ?? {})
+          : {};
         const projExpr = builtFinal.projectionExpression;
         const mergedNamesForProjection =
-          Object.keys(projNames).length > 0 ? { ...merged.expressionAttributeNames, ...projNames } : merged.expressionAttributeNames;
+          Object.keys(projNames).length > 0
+            ? { ...merged.expressionAttributeNames, ...projNames }
+            : merged.expressionAttributeNames;
 
         return {
           type: "Query",
@@ -297,7 +331,13 @@ export function createAccessPatternFactory(table: TableDef, discriminatorValue: 
   }
 
   return {
-    get<I>(fn: (input: I) => KeyParts & { consistentRead?: boolean; projectionExpression?: string; expressionAttributeNames?: Record<string, string> }): AccessPatternDef<I> {
+    get<I>(
+      fn: (input: I) => KeyParts & {
+        consistentRead?: boolean;
+        projectionExpression?: string;
+        expressionAttributeNames?: Record<string, string>;
+      },
+    ): AccessPatternDef<I> {
       return {
         name: "",
         kind: "get",
@@ -316,7 +356,8 @@ export function createAccessPatternFactory(table: TableDef, discriminatorValue: 
       };
     },
 
-    query: <I>(indexName: string | undefined, fn: (input: I) => QueryExtras<KeyParts>) => queryPattern(indexName, fn, "query"),
+    query: <I>(indexName: string | undefined, fn: (input: I) => QueryExtras<KeyParts>) =>
+      queryPattern(indexName, fn, "query"),
 
     unique: <I>(indexName: string, fn: (input: I) => { pk: string; sk?: string }) => {
       return {
@@ -362,12 +403,18 @@ export function createAccessPatternFactory(table: TableDef, discriminatorValue: 
           const fromInput = (input as Record<string, unknown>) ?? {};
           const builtFinal = {
             ...built,
-            limit: built.limit ?? (typeof fromInput.limit === "number" ? fromInput.limit : undefined),
+            limit:
+              built.limit ?? (typeof fromInput.limit === "number" ? fromInput.limit : undefined),
             consistentRead:
-              built.consistentRead ?? (typeof fromInput.consistentRead === "boolean" ? fromInput.consistentRead : undefined),
+              built.consistentRead ??
+              (typeof fromInput.consistentRead === "boolean"
+                ? fromInput.consistentRead
+                : undefined),
             projectionExpression:
               built.projectionExpression ??
-              (typeof fromInput.projectionExpression === "string" ? fromInput.projectionExpression : undefined),
+              (typeof fromInput.projectionExpression === "string"
+                ? fromInput.projectionExpression
+                : undefined),
             expressionAttributeNames:
               built.expressionAttributeNames ??
               (typeof fromInput.expressionAttributeNames === "object"
@@ -378,13 +425,23 @@ export function createAccessPatternFactory(table: TableDef, discriminatorValue: 
               (typeof fromInput.returnConsumedCapacity === "string"
                 ? (fromInput.returnConsumedCapacity as ScanExtras["returnConsumedCapacity"])
                 : undefined),
-            segment: built.segment ?? (typeof fromInput.segment === "number" ? fromInput.segment : undefined),
+            segment:
+              built.segment ??
+              (typeof fromInput.segment === "number" ? fromInput.segment : undefined),
             totalSegments:
-              built.totalSegments ?? (typeof fromInput.totalSegments === "number" ? fromInput.totalSegments : undefined),
-            cursor: built.cursor ?? (typeof fromInput.cursor === "string" ? (fromInput.cursor as OpaqueCursor) : undefined),
+              built.totalSegments ??
+              (typeof fromInput.totalSegments === "number" ? fromInput.totalSegments : undefined),
+            cursor:
+              built.cursor ??
+              (typeof fromInput.cursor === "string"
+                ? (fromInput.cursor as OpaqueCursor)
+                : undefined),
           };
           if (builtFinal.filterExpression) {
-            if (!builtFinal.filterExpressionAttributeNames || !builtFinal.filterExpressionAttributeValues) {
+            if (
+              !builtFinal.filterExpressionAttributeNames ||
+              !builtFinal.filterExpressionAttributeValues
+            ) {
               throw new ValidationError([
                 {
                   path: "filterExpression",

--- a/packages/core/src/aws-error.ts
+++ b/packages/core/src/aws-error.ts
@@ -1,7 +1,9 @@
 export function isConditionalCheckFailed(err: unknown): boolean {
   if (!err || typeof err !== "object") return false;
   const e = err as { name?: string; __type?: string };
-  return e.name === "ConditionalCheckFailedException" || e.__type === "ConditionalCheckFailedException";
+  return (
+    e.name === "ConditionalCheckFailedException" || e.__type === "ConditionalCheckFailedException"
+  );
 }
 
 export function isTransactionCanceled(err: unknown): boolean {
@@ -13,7 +15,10 @@ export function isTransactionCanceled(err: unknown): boolean {
 export function isIdempotentParameterMismatch(err: unknown): boolean {
   if (!err || typeof err !== "object") return false;
   const e = err as { name?: string; __type?: string };
-  return e.name === "IdempotentParameterMismatchException" || e.__type === "IdempotentParameterMismatchException";
+  return (
+    e.name === "IdempotentParameterMismatchException" ||
+    e.__type === "IdempotentParameterMismatchException"
+  );
 }
 
 export type AwsCancellationReason = {
@@ -25,7 +30,10 @@ export type AwsCancellationReason = {
 /** Best-effort read of cancellation reasons from AWS SDK / DynamoDB errors. */
 export function readTransactionCancellationReasons(err: unknown): readonly AwsCancellationReason[] {
   if (!err || typeof err !== "object") return [];
-  const e = err as { CancellationReasons?: AwsCancellationReason[]; cancellationReasons?: AwsCancellationReason[] };
+  const e = err as {
+    CancellationReasons?: AwsCancellationReason[];
+    cancellationReasons?: AwsCancellationReason[];
+  };
   const raw = e.CancellationReasons ?? e.cancellationReasons;
   return Array.isArray(raw) ? raw : [];
 }

--- a/packages/core/src/connect.ts
+++ b/packages/core/src/connect.ts
@@ -28,7 +28,10 @@ export interface ConnectOptions<E extends Record<string, CompiledEntity>> {
 }
 
 type TransactBundle = ReturnType<typeof createTransactServices>;
-type ConditionCheckFn = (fields: Record<string, FieldRef<unknown>>, op: typeof conditionOpsImpl) => unknown;
+type ConditionCheckFn = (
+  fields: Record<string, FieldRef<unknown>>,
+  op: typeof conditionOpsImpl,
+) => unknown;
 
 export type ConnectedDb<TTable extends TableDef, E extends Record<string, CompiledEntity>> = {
   readonly [K in keyof E]: ReturnType<typeof createRepository>;
@@ -39,7 +42,9 @@ export type ConnectedDb<TTable extends TableDef, E extends Record<string, Compil
   readonly entities: E;
   readonly tx: TransactBundle["tx"];
   readonly explain: { readonly tx: TransactBundle["explain"] };
-  readonly batchGet: (refs: Record<string, { entity: keyof E & string; key: Record<string, unknown> }>) => Promise<Record<string, unknown>>;
+  readonly batchGet: (
+    refs: Record<string, { entity: keyof E & string; key: Record<string, unknown> }>,
+  ) => Promise<Record<string, unknown>>;
   readonly orchestrate: {
     /**
      * Explicit labeled cross-entity transaction bundle.
@@ -50,10 +55,17 @@ export type ConnectedDb<TTable extends TableDef, E extends Record<string, Compil
         put: (label: string, ent: CompiledEntity, input: Record<string, unknown>) => void;
         update: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => unknown;
         delete: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => void;
-        conditionCheck: (label: string, ent: CompiledEntity, key: Record<string, unknown>, ifFn: ConditionCheckFn) => void;
+        conditionCheck: (
+          label: string,
+          ent: CompiledEntity,
+          key: Record<string, unknown>,
+          ifFn: ConditionCheckFn,
+        ) => void;
       }) => void | Promise<void>,
       options?: { clientRequestToken?: string },
-    ) => Promise<Record<string, { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }>>;
+    ) => Promise<
+      Record<string, { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }>
+    >;
     /**
      * Explicit fan-out write primitive for materialized view maintenance.
      * Executes primary and fan-out participants in one transaction.
@@ -64,19 +76,35 @@ export type ConnectedDb<TTable extends TableDef, E extends Record<string, Compil
           put: (label: string, ent: CompiledEntity, input: Record<string, unknown>) => void;
           update: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => unknown;
           delete: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => void;
-          conditionCheck: (label: string, ent: CompiledEntity, key: Record<string, unknown>, ifFn: ConditionCheckFn) => void;
+          conditionCheck: (
+            label: string,
+            ent: CompiledEntity,
+            key: Record<string, unknown>,
+            ifFn: ConditionCheckFn,
+          ) => void;
         }) => void | Promise<void>;
         fanOut?: (o: {
           put: (label: string, ent: CompiledEntity, input: Record<string, unknown>) => void;
           update: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => unknown;
           delete: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => void;
-          conditionCheck: (label: string, ent: CompiledEntity, key: Record<string, unknown>, ifFn: ConditionCheckFn) => void;
+          conditionCheck: (
+            label: string,
+            ent: CompiledEntity,
+            key: Record<string, unknown>,
+            ifFn: ConditionCheckFn,
+          ) => void;
         }) => void | Promise<void>;
       },
       options?: { clientRequestToken?: string },
     ) => Promise<{
-      primary: Record<string, { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }>;
-      fanOut: Record<string, { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }>;
+      primary: Record<
+        string,
+        { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }
+      >;
+      fanOut: Record<
+        string,
+        { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }
+      >;
     }>;
     counterSummary: (
       parts: {
@@ -84,19 +112,35 @@ export type ConnectedDb<TTable extends TableDef, E extends Record<string, Compil
           put: (label: string, ent: CompiledEntity, input: Record<string, unknown>) => void;
           update: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => unknown;
           delete: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => void;
-          conditionCheck: (label: string, ent: CompiledEntity, key: Record<string, unknown>, ifFn: ConditionCheckFn) => void;
+          conditionCheck: (
+            label: string,
+            ent: CompiledEntity,
+            key: Record<string, unknown>,
+            ifFn: ConditionCheckFn,
+          ) => void;
         }) => void | Promise<void>;
         summary?: (o: {
           put: (label: string, ent: CompiledEntity, input: Record<string, unknown>) => void;
           update: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => unknown;
           delete: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => void;
-          conditionCheck: (label: string, ent: CompiledEntity, key: Record<string, unknown>, ifFn: ConditionCheckFn) => void;
+          conditionCheck: (
+            label: string,
+            ent: CompiledEntity,
+            key: Record<string, unknown>,
+            ifFn: ConditionCheckFn,
+          ) => void;
         }) => void | Promise<void>;
       },
       options?: { clientRequestToken?: string },
     ) => Promise<{
-      primary: Record<string, { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }>;
-      summary: Record<string, { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }>;
+      primary: Record<
+        string,
+        { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }
+      >;
+      summary: Record<
+        string,
+        { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }
+      >;
     }>;
   };
   readonly read: {
@@ -109,14 +153,19 @@ export type ConnectedDb<TTable extends TableDef, E extends Record<string, Compil
       bundleName: string,
       input: Record<string, unknown>,
       opts?: { maxSteps?: number; maxDepth?: number; fanOutCap?: number },
-    ) => { readonly steps: readonly Record<string, unknown>[]; readonly warnings: readonly string[] };
+    ) => {
+      readonly steps: readonly Record<string, unknown>[];
+      readonly warnings: readonly string[];
+    };
   };
   readonly recipes: {
     run: (
       recipeName: string,
       input: Record<string, unknown>,
       options?: { clientRequestToken?: string },
-    ) => Promise<Record<string, { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }>>;
+    ) => Promise<
+      Record<string, { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }>
+    >;
     explain: (recipeName: string) => { readonly steps: readonly Record<string, unknown>[] };
   };
   readonly lifecycle: {
@@ -127,7 +176,9 @@ export type ConnectedDb<TTable extends TableDef, E extends Record<string, Compil
       deletedAtEpochSeconds: number;
       tombstone?: Record<string, unknown>;
       clientRequestToken?: string;
-    }) => Promise<Record<string, { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }>>;
+    }) => Promise<
+      Record<string, { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }>
+    >;
     archive: (spec: {
       archiveLabel?: string;
       sourceEntity: CompiledEntity;
@@ -138,12 +189,19 @@ export type ConnectedDb<TTable extends TableDef, E extends Record<string, Compil
       markDeletedAtEpochSeconds?: number;
       markFields?: Record<string, unknown>;
       clientRequestToken?: string;
-    }) => Promise<Record<string, { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }>>;
+    }) => Promise<
+      Record<string, { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }>
+    >;
   };
 };
 
 function isCompiled(x: unknown): x is CompiledEntity {
-  return typeof x === "object" && x !== null && COMPILED_ENTITY in x && (x as CompiledEntity)[COMPILED_ENTITY] === true;
+  return (
+    typeof x === "object" &&
+    x !== null &&
+    COMPILED_ENTITY in x &&
+    (x as CompiledEntity)[COMPILED_ENTITY] === true
+  );
 }
 
 export function connect<const T extends TableDef, const E extends Record<string, CompiledEntity>>(
@@ -174,19 +232,29 @@ export function connect<const T extends TableDef, const E extends Record<string,
     }
     out[key] = createRepository(ent.runtime, opts.adapter);
   }
-  const rels: RelationsConfig = opts.relations ? createRelations(opts.entities, opts.relations) : [];
-  const bundles: ReadBundlesConfig = opts.readBundles ? createReadBundles(opts.entities, opts.readBundles) : [];
-  const recipes: WriteRecipesConfig = opts.writeRecipes ? createWriteRecipes(opts.entities, opts.writeRecipes) : [];
+  const rels: RelationsConfig = opts.relations
+    ? createRelations(opts.entities, opts.relations)
+    : [];
+  const bundles: ReadBundlesConfig = opts.readBundles
+    ? createReadBundles(opts.entities, opts.readBundles)
+    : [];
+  const recipes: WriteRecipesConfig = opts.writeRecipes
+    ? createWriteRecipes(opts.entities, opts.writeRecipes)
+    : [];
   if (rels.length > 0) {
     applyRelations(out, rels);
   }
 
-  out.batchGet = async (refs: Record<string, { entity: keyof E & string; key: Record<string, unknown> }>) => {
+  out.batchGet = async (
+    refs: Record<string, { entity: keyof E & string; key: Record<string, unknown> }>,
+  ) => {
     const result: Record<string, unknown> = {};
     for (const label of Object.keys(refs)) {
       const spec = refs[label];
       if (!spec) continue;
-      const repo = out[spec.entity] as { get?: (key: Record<string, unknown>) => Promise<unknown> } | undefined;
+      const repo = out[spec.entity] as
+        | { get?: (key: Record<string, unknown>) => Promise<unknown> }
+        | undefined;
       if (!repo?.get) {
         result[label] = null;
         continue;
@@ -201,11 +269,19 @@ export function connect<const T extends TableDef, const E extends Record<string,
       put: (label: string, ent: CompiledEntity, input: Record<string, unknown>) => void;
       update: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => unknown;
       delete: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => void;
-      conditionCheck: (label: string, ent: CompiledEntity, key: Record<string, unknown>, ifFn: ConditionCheckFn) => void;
+      conditionCheck: (
+        label: string,
+        ent: CompiledEntity,
+        key: Record<string, unknown>,
+        ifFn: ConditionCheckFn,
+      ) => void;
     }) => void | Promise<void>,
     options?: { clientRequestToken?: string },
   ) => {
-    const labels: Record<string, { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }> = {};
+    const labels: Record<
+      string,
+      { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }
+    > = {};
     await transact.tx.write(async (w) => {
       await fn({
         put: (label, ent, input) => {
@@ -235,22 +311,41 @@ export function connect<const T extends TableDef, const E extends Record<string,
         put: (label: string, ent: CompiledEntity, input: Record<string, unknown>) => void;
         update: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => unknown;
         delete: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => void;
-        conditionCheck: (label: string, ent: CompiledEntity, key: Record<string, unknown>, ifFn: ConditionCheckFn) => void;
+        conditionCheck: (
+          label: string,
+          ent: CompiledEntity,
+          key: Record<string, unknown>,
+          ifFn: ConditionCheckFn,
+        ) => void;
       }) => void | Promise<void>;
       fanOut?: (o: {
         put: (label: string, ent: CompiledEntity, input: Record<string, unknown>) => void;
         update: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => unknown;
         delete: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => void;
-        conditionCheck: (label: string, ent: CompiledEntity, key: Record<string, unknown>, ifFn: ConditionCheckFn) => void;
+        conditionCheck: (
+          label: string,
+          ent: CompiledEntity,
+          key: Record<string, unknown>,
+          ifFn: ConditionCheckFn,
+        ) => void;
       }) => void | Promise<void>;
     },
     options?: { clientRequestToken?: string },
   ) => {
-    const primary: Record<string, { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }> = {};
-    const fanOut: Record<string, { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }> = {};
+    const primary: Record<
+      string,
+      { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }
+    > = {};
+    const fanOut: Record<
+      string,
+      { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }
+    > = {};
     await transact.tx.write(async (w) => {
       const bind = (
-        sink: Record<string, { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }>,
+        sink: Record<
+          string,
+          { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }
+        >,
       ) => ({
         put: (label: string, ent: CompiledEntity, input: Record<string, unknown>) => {
           sink[label] = { operation: "Put", entity: ent.runtime.entityName };
@@ -264,7 +359,12 @@ export function connect<const T extends TableDef, const E extends Record<string,
           sink[label] = { operation: "Delete", entity: ent.runtime.entityName };
           w.delete(ent, key);
         },
-        conditionCheck: (label: string, ent: CompiledEntity, key: Record<string, unknown>, ifFn: ConditionCheckFn) => {
+        conditionCheck: (
+          label: string,
+          ent: CompiledEntity,
+          key: Record<string, unknown>,
+          ifFn: ConditionCheckFn,
+        ) => {
           sink[label] = { operation: "ConditionCheck", entity: ent.runtime.entityName };
           w.conditionCheck(ent, key, (fields, op) => ifFn(fields, op) as ConditionExpr);
         },
@@ -281,7 +381,12 @@ export function connect<const T extends TableDef, const E extends Record<string,
         put: (label: string, ent: CompiledEntity, input: Record<string, unknown>) => void;
         update: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => unknown;
         delete: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => void;
-        conditionCheck: (label: string, ent: CompiledEntity, key: Record<string, unknown>, ifFn: (...args: unknown[]) => unknown) => void;
+        conditionCheck: (
+          label: string,
+          ent: CompiledEntity,
+          key: Record<string, unknown>,
+          ifFn: (...args: unknown[]) => unknown,
+        ) => void;
       }) => void | Promise<void>,
       options?: { clientRequestToken?: string },
     ) => runOrchestrationWrite(fn, options),
@@ -291,13 +396,23 @@ export function connect<const T extends TableDef, const E extends Record<string,
           put: (label: string, ent: CompiledEntity, input: Record<string, unknown>) => void;
           update: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => unknown;
           delete: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => void;
-          conditionCheck: (label: string, ent: CompiledEntity, key: Record<string, unknown>, ifFn: (...args: unknown[]) => unknown) => void;
+          conditionCheck: (
+            label: string,
+            ent: CompiledEntity,
+            key: Record<string, unknown>,
+            ifFn: (...args: unknown[]) => unknown,
+          ) => void;
         }) => void | Promise<void>;
         fanOut?: (o: {
           put: (label: string, ent: CompiledEntity, input: Record<string, unknown>) => void;
           update: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => unknown;
           delete: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => void;
-          conditionCheck: (label: string, ent: CompiledEntity, key: Record<string, unknown>, ifFn: (...args: unknown[]) => unknown) => void;
+          conditionCheck: (
+            label: string,
+            ent: CompiledEntity,
+            key: Record<string, unknown>,
+            ifFn: (...args: unknown[]) => unknown,
+          ) => void;
         }) => void | Promise<void>;
       },
       options?: { clientRequestToken?: string },
@@ -308,13 +423,23 @@ export function connect<const T extends TableDef, const E extends Record<string,
           put: (label: string, ent: CompiledEntity, input: Record<string, unknown>) => void;
           update: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => unknown;
           delete: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => void;
-          conditionCheck: (label: string, ent: CompiledEntity, key: Record<string, unknown>, ifFn: (...args: unknown[]) => unknown) => void;
+          conditionCheck: (
+            label: string,
+            ent: CompiledEntity,
+            key: Record<string, unknown>,
+            ifFn: (...args: unknown[]) => unknown,
+          ) => void;
         }) => void | Promise<void>;
         summary?: (o: {
           put: (label: string, ent: CompiledEntity, input: Record<string, unknown>) => void;
           update: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => unknown;
           delete: (label: string, ent: CompiledEntity, key: Record<string, unknown>) => void;
-          conditionCheck: (label: string, ent: CompiledEntity, key: Record<string, unknown>, ifFn: (...args: unknown[]) => unknown) => void;
+          conditionCheck: (
+            label: string,
+            ent: CompiledEntity,
+            key: Record<string, unknown>,
+            ifFn: (...args: unknown[]) => unknown,
+          ) => void;
         }) => void | Promise<void>;
       },
       options?: { clientRequestToken?: string },
@@ -384,163 +509,230 @@ export function connect<const T extends TableDef, const E extends Record<string,
 
   const bundleMap = new Map(bundles.map((b) => [b.name, b]));
   out.read = {
-      run: async (
-        bundleName: string,
-        input: Record<string, unknown>,
-        opts?: { maxSteps?: number; maxDepth?: number; fanOutCap?: number },
-      ) => {
-        const plan = bundleMap.get(bundleName);
-        if (!plan) {
-          throw new ValidationError([{ path: `read.bundle.${bundleName}`, message: "Unknown read bundle" }]);
+    run: async (
+      bundleName: string,
+      input: Record<string, unknown>,
+      opts?: { maxSteps?: number; maxDepth?: number; fanOutCap?: number },
+    ) => {
+      const plan = bundleMap.get(bundleName);
+      if (!plan) {
+        throw new ValidationError([
+          { path: `read.bundle.${bundleName}`, message: "Unknown read bundle" },
+        ]);
+      }
+      const maxSteps = opts?.maxSteps ?? 20;
+      if (plan.steps.length > maxSteps) {
+        throw new ValidationError([
+          { path: `read.bundle.${bundleName}`, message: `Bundle exceeds maxSteps (${maxSteps})` },
+        ]);
+      }
+      const maxDepth = opts?.maxDepth ?? plan.maxDepth ?? 1;
+      if (maxDepth > 1) {
+        throw new ValidationError([
+          {
+            path: `read.bundle.${bundleName}`,
+            message: "Only one-hop bundles are supported in v0.6",
+          },
+        ]);
+      }
+      const result: Record<string, unknown> = {};
+      let fanout = 0;
+      for (const step of plan.steps) {
+        if (step.kind === "rootGet") {
+          const repo = out[step.entity] as
+            | { get?: (k: Record<string, unknown>) => Promise<unknown> }
+            | undefined;
+          if (!repo?.get)
+            throw new ValidationError([
+              {
+                path: `read.bundle.${bundleName}.${step.label}`,
+                message: "Entity repo/get not found",
+              },
+            ]);
+          result[step.label] = await repo.get(step.mapInput(input));
+          continue;
         }
-        const maxSteps = opts?.maxSteps ?? 20;
-        if (plan.steps.length > maxSteps) {
-          throw new ValidationError([{ path: `read.bundle.${bundleName}`, message: `Bundle exceeds maxSteps (${maxSteps})` }]);
-        }
-        const maxDepth = opts?.maxDepth ?? plan.maxDepth ?? 1;
-        if (maxDepth > 1) {
-          throw new ValidationError([{ path: `read.bundle.${bundleName}`, message: "Only one-hop bundles are supported in v0.6" }]);
-        }
-        const result: Record<string, unknown> = {};
-        let fanout = 0;
-        for (const step of plan.steps) {
-          if (step.kind === "rootGet") {
-            const repo = out[step.entity] as { get?: (k: Record<string, unknown>) => Promise<unknown> } | undefined;
-            if (!repo?.get) throw new ValidationError([{ path: `read.bundle.${bundleName}.${step.label}`, message: "Entity repo/get not found" }]);
-            result[step.label] = await repo.get(step.mapInput(input));
-            continue;
-          }
-          if (step.kind === "rootPattern") {
-            const repo = out[step.entity] as { find?: Record<string, (i: Record<string, unknown>) => Promise<unknown>> } | undefined;
-            const fn = repo?.find?.[step.pattern];
-            if (typeof fn !== "function") {
-              throw new ValidationError([{ path: `read.bundle.${bundleName}.${step.label}`, message: `Unknown pattern "${step.pattern}"` }]);
-            }
-            result[step.label] = await fn(step.mapInput(input));
-            const page = result[step.label] as { items?: readonly unknown[] };
-            fanout += page.items?.length ?? 0;
-            continue;
-          }
-          const rootRepo = out[step.root] as Record<string, unknown> | undefined;
-          const rel = (rootRepo?.[step.alias] as Record<string, (i: Record<string, unknown>) => Promise<unknown>> | undefined) ?? undefined;
-          const fn = rel?.[step.method];
+        if (step.kind === "rootPattern") {
+          const repo = out[step.entity] as
+            | { find?: Record<string, (i: Record<string, unknown>) => Promise<unknown>> }
+            | undefined;
+          const fn = repo?.find?.[step.pattern];
           if (typeof fn !== "function") {
-            throw new ValidationError([{ path: `read.bundle.${bundleName}.${step.label}`, message: `Unknown relation route "${step.root}.${step.alias}.${step.method}"` }]);
+            throw new ValidationError([
+              {
+                path: `read.bundle.${bundleName}.${step.label}`,
+                message: `Unknown pattern "${step.pattern}"`,
+              },
+            ]);
           }
-          const val = await fn(step.mapInput(input));
-          if (step.method === "list") {
-            const page = val as { items?: readonly unknown[] };
-            fanout += page.items?.length ?? 0;
-            result[step.label] = page.items ?? [];
-          } else if (step.method === "listTargets") {
-            const arr = (val as readonly unknown[]) ?? [];
-            fanout += arr.length;
-            result[step.label] = arr;
-          } else {
-            result[step.label] = val ?? null;
-          }
+          result[step.label] = await fn(step.mapInput(input));
+          const page = result[step.label] as { items?: readonly unknown[] };
+          fanout += page.items?.length ?? 0;
+          continue;
         }
-        const cap = opts?.fanOutCap;
-        if (cap !== undefined && fanout > cap) {
-          throw new ValidationError([{ path: `read.bundle.${bundleName}`, message: `Bundle fanout ${fanout} exceeded cap ${cap}` }]);
+        const rootRepo = out[step.root] as Record<string, unknown> | undefined;
+        const rel =
+          (rootRepo?.[step.alias] as
+            | Record<string, (i: Record<string, unknown>) => Promise<unknown>>
+            | undefined) ?? undefined;
+        const fn = rel?.[step.method];
+        if (typeof fn !== "function") {
+          throw new ValidationError([
+            {
+              path: `read.bundle.${bundleName}.${step.label}`,
+              message: `Unknown relation route "${step.root}.${step.alias}.${step.method}"`,
+            },
+          ]);
         }
-        return result;
-      },
-      explain: (
-        bundleName: string,
-        input: Record<string, unknown>,
-        opts?: { maxSteps?: number; maxDepth?: number; fanOutCap?: number },
-      ) => {
-        const plan = bundleMap.get(bundleName);
-        if (!plan) {
-          throw new ValidationError([{ path: `read.bundle.${bundleName}`, message: "Unknown read bundle" }]);
+        const val = await fn(step.mapInput(input));
+        if (step.method === "list") {
+          const page = val as { items?: readonly unknown[] };
+          fanout += page.items?.length ?? 0;
+          result[step.label] = page.items ?? [];
+        } else if (step.method === "listTargets") {
+          const arr = (val as readonly unknown[]) ?? [];
+          fanout += arr.length;
+          result[step.label] = arr;
+        } else {
+          result[step.label] = val ?? null;
         }
-        const maxSteps = opts?.maxSteps ?? 20;
-        const maxDepth = opts?.maxDepth ?? plan.maxDepth ?? 1;
-        const warnings: string[] = [];
-        if (plan.steps.length > maxSteps) warnings.push(`Step count ${plan.steps.length} exceeds maxSteps ${maxSteps}`);
-        if (maxDepth > 1) warnings.push("Only one-hop bundles are supported in v0.6");
-        const steps = plan.steps.map((step) => {
-          if (step.kind === "rootGet") {
-            return { label: step.label, kind: step.kind, entity: step.entity };
-          }
-          if (step.kind === "rootPattern") {
-            if (step.pattern.toLowerCase().includes("scan")) {
-              warnings.push(`Step "${step.label}" may be scan-backed; verify access-pattern cost.`);
-            }
-            return { label: step.label, kind: step.kind, entity: step.entity, pattern: step.pattern, input: step.mapInput(input) };
-          }
-          if (step.method === "list" || step.method === "listTargets") {
-            warnings.push(`Step "${step.label}" is collection expansion; watch fanout cost.`);
+      }
+      const cap = opts?.fanOutCap;
+      if (cap !== undefined && fanout > cap) {
+        throw new ValidationError([
+          {
+            path: `read.bundle.${bundleName}`,
+            message: `Bundle fanout ${fanout} exceeded cap ${cap}`,
+          },
+        ]);
+      }
+      return result;
+    },
+    explain: (
+      bundleName: string,
+      input: Record<string, unknown>,
+      opts?: { maxSteps?: number; maxDepth?: number; fanOutCap?: number },
+    ) => {
+      const plan = bundleMap.get(bundleName);
+      if (!plan) {
+        throw new ValidationError([
+          { path: `read.bundle.${bundleName}`, message: "Unknown read bundle" },
+        ]);
+      }
+      const maxSteps = opts?.maxSteps ?? 20;
+      const maxDepth = opts?.maxDepth ?? plan.maxDepth ?? 1;
+      const warnings: string[] = [];
+      if (plan.steps.length > maxSteps)
+        warnings.push(`Step count ${plan.steps.length} exceeds maxSteps ${maxSteps}`);
+      if (maxDepth > 1) warnings.push("Only one-hop bundles are supported in v0.6");
+      const steps = plan.steps.map((step) => {
+        if (step.kind === "rootGet") {
+          return { label: step.label, kind: step.kind, entity: step.entity };
+        }
+        if (step.kind === "rootPattern") {
+          if (step.pattern.toLowerCase().includes("scan")) {
+            warnings.push(`Step "${step.label}" may be scan-backed; verify access-pattern cost.`);
           }
           return {
             label: step.label,
             kind: step.kind,
-            root: step.root,
-            alias: step.alias,
-            method: step.method,
+            entity: step.entity,
+            pattern: step.pattern,
             input: step.mapInput(input),
           };
-        });
-        return { steps, warnings };
-      },
-    };
+        }
+        if (step.method === "list" || step.method === "listTargets") {
+          warnings.push(`Step "${step.label}" is collection expansion; watch fanout cost.`);
+        }
+        return {
+          label: step.label,
+          kind: step.kind,
+          root: step.root,
+          alias: step.alias,
+          method: step.method,
+          input: step.mapInput(input),
+        };
+      });
+      return { steps, warnings };
+    },
+  };
 
   const recipeMap = new Map(recipes.map((r) => [r.name, r]));
   out.recipes = {
-      run: async (
-        recipeName: string,
-        input: Record<string, unknown>,
-        options?: { clientRequestToken?: string },
-      ) => {
-        const recipe = recipeMap.get(recipeName);
-        if (!recipe) throw new ValidationError([{ path: `recipes.${recipeName}`, message: "Unknown write recipe" }]);
-        await transact.tx.write(async (w) => {
-          for (const step of recipe.steps) {
-            const ent = opts.entities[step.entity];
-            if (!ent) throw new ValidationError([{ path: `recipes.${recipeName}.${step.label}`, message: `Unknown entity "${step.entity}"` }]);
-            if (step.kind === "put") {
-              w.put(ent, step.mapInput(input));
-              continue;
-            }
-            if (step.kind === "delete") {
-              w.delete(ent, step.mapKey(input));
-              continue;
-            }
-            if (step.kind === "conditionCheck") {
-              w.conditionCheck(ent, step.mapKey(input), (fields, op) => step.ifFn(fields, op) as ConditionExpr);
-              continue;
-            }
-            const u = w.update(ent, step.mapKey(input));
-            step.apply(u, input);
+    run: async (
+      recipeName: string,
+      input: Record<string, unknown>,
+      options?: { clientRequestToken?: string },
+    ) => {
+      const recipe = recipeMap.get(recipeName);
+      if (!recipe)
+        throw new ValidationError([
+          { path: `recipes.${recipeName}`, message: "Unknown write recipe" },
+        ]);
+      await transact.tx.write(async (w) => {
+        for (const step of recipe.steps) {
+          const ent = opts.entities[step.entity];
+          if (!ent)
+            throw new ValidationError([
+              {
+                path: `recipes.${recipeName}.${step.label}`,
+                message: `Unknown entity "${step.entity}"`,
+              },
+            ]);
+          if (step.kind === "put") {
+            w.put(ent, step.mapInput(input));
+            continue;
           }
-        }, options);
-        return recipe.steps.reduce<Record<string, { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }>>((acc, step) => {
-          acc[step.label] = {
-            operation:
-              step.kind === "put"
-                ? "Put"
-                : step.kind === "delete"
-                  ? "Delete"
-                  : step.kind === "conditionCheck"
-                    ? "ConditionCheck"
-                    : "Update",
-            entity: step.entity,
-          };
-          return acc;
-        }, {});
-      },
-      explain: (recipeName: string) => {
-        const recipe = recipeMap.get(recipeName);
-        if (!recipe) throw new ValidationError([{ path: `recipes.${recipeName}`, message: "Unknown write recipe" }]);
-        const steps = recipe.steps.map((step) => ({
-          label: step.label,
-          kind: step.kind,
+          if (step.kind === "delete") {
+            w.delete(ent, step.mapKey(input));
+            continue;
+          }
+          if (step.kind === "conditionCheck") {
+            w.conditionCheck(
+              ent,
+              step.mapKey(input),
+              (fields, op) => step.ifFn(fields, op) as ConditionExpr,
+            );
+            continue;
+          }
+          const u = w.update(ent, step.mapKey(input));
+          step.apply(u, input);
+        }
+      }, options);
+      return recipe.steps.reduce<
+        Record<
+          string,
+          { operation: "Put" | "Update" | "Delete" | "ConditionCheck"; entity: string }
+        >
+      >((acc, step) => {
+        acc[step.label] = {
+          operation:
+            step.kind === "put"
+              ? "Put"
+              : step.kind === "delete"
+                ? "Delete"
+                : step.kind === "conditionCheck"
+                  ? "ConditionCheck"
+                  : "Update",
           entity: step.entity,
-        }));
-        return { steps };
-      },
-    };
+        };
+        return acc;
+      }, {});
+    },
+    explain: (recipeName: string) => {
+      const recipe = recipeMap.get(recipeName);
+      if (!recipe)
+        throw new ValidationError([
+          { path: `recipes.${recipeName}`, message: "Unknown write recipe" },
+        ]);
+      const steps = recipe.steps.map((step) => ({
+        label: step.label,
+        kind: step.kind,
+        entity: step.entity,
+      }));
+      return { steps };
+    },
+  };
 
   return out as ConnectedDb<T, E>;
 }

--- a/packages/core/src/entity.ts
+++ b/packages/core/src/entity.ts
@@ -18,7 +18,10 @@ export type CompiledEntity<
 };
 
 type KeyBuilder = (logical: Record<string, unknown>) => { pk: string; sk?: string };
-type GsiEntry = { indexName: string; fn: (logical: Record<string, unknown>) => Record<string, string> };
+type GsiEntry = {
+  indexName: string;
+  fn: (logical: Record<string, unknown>) => Record<string, string>;
+};
 
 interface EntityState<Name extends string, S extends SchemaRecord> {
   entityName: Name;
@@ -58,7 +61,9 @@ export class EntityDraft<const Name extends string, const S extends SchemaRecord
 class EntityWithTable<const Name extends string, const S extends SchemaRecord, T extends TableDef> {
   constructor(private readonly st: EntityState<Name, S>) {}
 
-  keys(fn: (input: Record<string, unknown>) => { pk: string; sk?: string }): EntityWithKeys<Name, S, T> {
+  keys(
+    fn: (input: Record<string, unknown>) => { pk: string; sk?: string },
+  ): EntityWithKeys<Name, S, T> {
     this.st.keyFn = fn as KeyBuilder;
     return new EntityWithKeys(this.st);
   }
@@ -81,7 +86,11 @@ class EntityWithKeys<const Name extends string, const S extends SchemaRecord, T 
   }
 }
 
-class EntityWithIdentity<const Name extends string, const S extends SchemaRecord, const Id extends readonly (keyof S & string)[]> {
+class EntityWithIdentity<
+  const Name extends string,
+  const S extends SchemaRecord,
+  const Id extends readonly (keyof S & string)[],
+> {
   constructor(private readonly st: EntityState<Name, S>) {}
 
   accessPatterns(
@@ -91,7 +100,9 @@ class EntityWithIdentity<const Name extends string, const S extends SchemaRecord
     const keyFn = this.st.keyFn;
     const identityKeys = this.st.identityKeys;
     if (!table || !keyFn || !identityKeys) {
-      throw new ConfigurationError("entity: incomplete chain (inTable → keys → identity → accessPatterns)");
+      throw new ConfigurationError(
+        "entity: incomplete chain (inTable → keys → identity → accessPatterns)",
+      );
     }
     assertNoReservedLogicalNames(table, this.st.schema);
     const ap = createAccessPatternFactory(table, this.st.entityName);
@@ -114,7 +125,11 @@ class EntityWithIdentity<const Name extends string, const S extends SchemaRecord
       gsiProjections: this.st.gsi,
       accessPatterns: patterns,
     };
-    return { [COMPILED_ENTITY]: true as const, runtime, _identityKeys: identityKeys } as CompiledEntity<S, Id>;
+    return {
+      [COMPILED_ENTITY]: true as const,
+      runtime,
+      _identityKeys: identityKeys,
+    } as CompiledEntity<S, Id>;
   }
 }
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -38,7 +38,11 @@ export class ConditionFailedError extends DynamoModelError {
 export class ItemAlreadyExistsError extends DynamoModelError {
   readonly code = "ITEM_ALREADY_EXISTS" as const;
   readonly entity?: string;
-  constructor(message = "Item already exists", entity?: string, readonly cause?: unknown) {
+  constructor(
+    message = "Item already exists",
+    entity?: string,
+    readonly cause?: unknown,
+  ) {
     super("ITEM_ALREADY_EXISTS", message);
     this.name = "ItemAlreadyExistsError";
     this.entity = entity;
@@ -92,7 +96,11 @@ export class TransactionCanceledError extends DynamoModelError {
   readonly code = "TRANSACTION_CANCELED" as const;
   readonly reasons: readonly TransactionCancellationReason[];
   readonly cause?: unknown;
-  constructor(reasons: readonly TransactionCancellationReason[], message?: string, cause?: unknown) {
+  constructor(
+    reasons: readonly TransactionCancellationReason[],
+    message?: string,
+    cause?: unknown,
+  ) {
     super(
       "TRANSACTION_CANCELED",
       message ??
@@ -107,7 +115,10 @@ export class TransactionCanceledError extends DynamoModelError {
 export class IdempotentParameterMismatchError extends DynamoModelError {
   readonly code = "IDEMPOTENT_PARAMETER_MISMATCH" as const;
   readonly cause?: unknown;
-  constructor(message = "ClientRequestToken was reused with different request parameters", cause?: unknown) {
+  constructor(
+    message = "ClientRequestToken was reused with different request parameters",
+    cause?: unknown,
+  ) {
     super("IDEMPOTENT_PARAMETER_MISMATCH", message);
     this.name = "IdempotentParameterMismatchError";
     this.cause = cause;

--- a/packages/core/src/explain-helpers.ts
+++ b/packages/core/src/explain-helpers.ts
@@ -17,7 +17,10 @@ export function emptyCompiled(
   };
 }
 
-export function explainGetItem(runtime: EntityRuntime, logical: Record<string, unknown>): CompiledOperation {
+export function explainGetItem(
+  runtime: EntityRuntime,
+  logical: Record<string, unknown>,
+): CompiledOperation {
   const key = buildPrimaryKeyMap(runtime, logical);
   return {
     ...emptyCompiled(runtime.entityName, "GetItem", runtime.table.name),
@@ -25,7 +28,10 @@ export function explainGetItem(runtime: EntityRuntime, logical: Record<string, u
   };
 }
 
-export function explainDeleteItem(runtime: EntityRuntime, logical: Record<string, unknown>): CompiledOperation {
+export function explainDeleteItem(
+  runtime: EntityRuntime,
+  logical: Record<string, unknown>,
+): CompiledOperation {
   const key = buildPrimaryKeyMap(runtime, logical);
   return {
     ...emptyCompiled(runtime.entityName, "DeleteItem", runtime.table.name),

--- a/packages/core/src/fields.ts
+++ b/packages/core/src/fields.ts
@@ -116,7 +116,11 @@ export function id<const P extends string>(
     isVersion: false,
     idPrefix: prefix,
   });
-  return Object.assign(f, { _idPrefix: prefix }) as FieldApi<Brand<string, `${P}Id`>, false, false> & {
+  return Object.assign(f, { _idPrefix: prefix }) as FieldApi<
+    Brand<string, `${P}Id`>,
+    false,
+    false
+  > & {
     readonly _idPrefix: P;
   };
 }
@@ -169,7 +173,11 @@ export function record<const V extends FieldDef>(
     isVersion: false,
     recordValueField: valueField,
   });
-  return Object.assign(f, { _recordValue: valueField }) as FieldApi<Record<string, FieldToValue<V>>, false, false> & {
+  return Object.assign(f, { _recordValue: valueField }) as FieldApi<
+    Record<string, FieldToValue<V>>,
+    false,
+    false
+  > & {
     readonly _recordValue: V;
   };
 }
@@ -185,7 +193,11 @@ export function list<const V extends FieldDef>(
     isVersion: false,
     listItemField: itemField,
   });
-  return Object.assign(f, { _listItem: itemField }) as FieldApi<readonly FieldToValue<V>[], false, false> & {
+  return Object.assign(f, { _listItem: itemField }) as FieldApi<
+    readonly FieldToValue<V>[],
+    false,
+    false
+  > & {
     readonly _listItem: V;
   };
 }
@@ -233,22 +245,22 @@ type FieldToValue<F extends FieldDef> = F["_kind"] extends "string"
               : F["_kind"] extends "ttl"
                 ? number
                 : F["_kind"] extends "object"
-                ? F extends { objectShape: infer O extends SchemaRecord }
-                  ? InferItem<O>
-                  : Record<string, unknown>
-                : F["_kind"] extends "record"
-                  ? F extends { recordValueField: infer V extends FieldDef }
-                    ? Record<string, FieldToValue<V>>
+                  ? F extends { objectShape: infer O extends SchemaRecord }
+                    ? InferItem<O>
                     : Record<string, unknown>
-                  : F["_kind"] extends "list"
-                    ? F extends { listItemField: infer V extends FieldDef }
-                      ? readonly FieldToValue<V>[]
-                      : readonly unknown[]
-                    : F["_kind"] extends "stringSet"
-                      ? ReadonlySet<string>
-                      : F["_kind"] extends "numberSet"
-                        ? ReadonlySet<number>
-                        : unknown;
+                  : F["_kind"] extends "record"
+                    ? F extends { recordValueField: infer V extends FieldDef }
+                      ? Record<string, FieldToValue<V>>
+                      : Record<string, unknown>
+                    : F["_kind"] extends "list"
+                      ? F extends { listItemField: infer V extends FieldDef }
+                        ? readonly FieldToValue<V>[]
+                        : readonly unknown[]
+                      : F["_kind"] extends "stringSet"
+                        ? ReadonlySet<string>
+                        : F["_kind"] extends "numberSet"
+                          ? ReadonlySet<number>
+                          : unknown;
 
 export type InferItem<S extends SchemaRecord> = {
   [K in keyof S]: S[K]["_required"] extends true
@@ -268,7 +280,10 @@ type RequiredKeysNoDefault<S extends SchemaRecord> = {
 
 type OptionalOrDefaultKeys<S extends SchemaRecord> = Exclude<keyof S, RequiredKeysNoDefault<S>>;
 
-export type CreateInput<S extends SchemaRecord> = Pick<InferItem<S>, RequiredKeysNoDefault<S> & keyof S> &
+export type CreateInput<S extends SchemaRecord> = Pick<
+  InferItem<S>,
+  RequiredKeysNoDefault<S> & keyof S
+> &
   Partial<Pick<InferItem<S>, OptionalOrDefaultKeys<S> & keyof S>>;
 
 export type PrimaryKeyInput<S extends SchemaRecord, Id extends readonly (keyof S)[]> = Pick<
@@ -303,7 +318,10 @@ export type AddableKeys<S extends SchemaRecord> = {
 }[keyof S];
 
 /** Numeric ADD surface (disjoint from Settable: version counters only in v0.1) */
-export type AddableShape<S extends SchemaRecord> = Pick<InferItem<S>, AddableKeys<S> & keyof InferItem<S>>;
+export type AddableShape<S extends SchemaRecord> = Pick<
+  InferItem<S>,
+  AddableKeys<S> & keyof InferItem<S>
+>;
 
 export type RemovableKeys<S extends SchemaRecord> = {
   [K in keyof S]: S[K] extends FieldDef
@@ -327,7 +345,10 @@ export function fieldRef<T>(path: string): FieldRef<T> {
   return { __brand: "FieldRef", path };
 }
 
-export function pathRef<T>(base: FieldRef<unknown>, ...segments: ReadonlyArray<string | number>): FieldRef<T> {
+export function pathRef<T>(
+  base: FieldRef<unknown>,
+  ...segments: ReadonlyArray<string | number>
+): FieldRef<T> {
   let path = base.path;
   for (const seg of segments) {
     path += typeof seg === "number" ? `[${seg}]` : `.${seg}`;

--- a/packages/core/src/relations.ts
+++ b/packages/core/src/relations.ts
@@ -4,7 +4,10 @@ import type { FieldRef } from "./fields.js";
 import { conditionOpsImpl } from "./update.js";
 
 type EntityMap = Record<string, CompiledEntity>;
-type ConditionCheckFn = (fields: Record<string, FieldRef<unknown>>, op: typeof conditionOpsImpl) => unknown;
+type ConditionCheckFn = (
+  fields: Record<string, FieldRef<unknown>>,
+  op: typeof conditionOpsImpl,
+) => unknown;
 
 export type HasManyDecl = {
   readonly kind: "hasMany";
@@ -130,7 +133,10 @@ export class RelationBuilder<E extends EntityMap> {
   belongsTo(
     source: keyof E & string,
     alias: string,
-    opts: { target: keyof E & string; mapGet: (input: Record<string, unknown>) => Record<string, unknown> },
+    opts: {
+      target: keyof E & string;
+      mapGet: (input: Record<string, unknown>) => Record<string, unknown>;
+    },
   ): this {
     this.rels.push({
       kind: "belongsTo",
@@ -178,7 +184,9 @@ export class ReadBundleStepBuilder<E extends EntityMap> {
 
   private assertLabel(label: string): void {
     if (this.labels.has(label)) {
-      throw new ValidationError([{ path: `readBundle.${label}`, message: "Duplicate bundle label" }]);
+      throw new ValidationError([
+        { path: `readBundle.${label}`, message: "Duplicate bundle label" },
+      ]);
     }
     this.labels.add(label);
   }
@@ -189,7 +197,11 @@ export class ReadBundleStepBuilder<E extends EntityMap> {
     }
   }
 
-  rootGet(label: string, entity: keyof E & string, mapInput: (input: Record<string, unknown>) => Record<string, unknown>): this {
+  rootGet(
+    label: string,
+    entity: keyof E & string,
+    mapInput: (input: Record<string, unknown>) => Record<string, unknown>,
+  ): this {
     this.assertLabel(label);
     this.assertEntity(entity, `readBundle.${label}.entity`);
     this.steps.push({ kind: "rootGet", label, entity, mapInput });
@@ -257,7 +269,9 @@ export class WriteRecipeStepBuilder<E extends EntityMap> {
 
   private assertLabel(label: string): void {
     if (this.labels.has(label)) {
-      throw new ValidationError([{ path: `writeRecipe.${label}`, message: "Duplicate recipe label" }]);
+      throw new ValidationError([
+        { path: `writeRecipe.${label}`, message: "Duplicate recipe label" },
+      ]);
     }
     this.labels.add(label);
   }
@@ -268,14 +282,22 @@ export class WriteRecipeStepBuilder<E extends EntityMap> {
     }
   }
 
-  put(label: string, entity: keyof E & string, mapInput: (input: Record<string, unknown>) => Record<string, unknown>): this {
+  put(
+    label: string,
+    entity: keyof E & string,
+    mapInput: (input: Record<string, unknown>) => Record<string, unknown>,
+  ): this {
     this.assertLabel(label);
     this.assertEntity(entity, `writeRecipe.${label}.entity`);
     this.steps.push({ kind: "put", label, entity, mapInput });
     return this;
   }
 
-  delete(label: string, entity: keyof E & string, mapKey: (input: Record<string, unknown>) => Record<string, unknown>): this {
+  delete(
+    label: string,
+    entity: keyof E & string,
+    mapKey: (input: Record<string, unknown>) => Record<string, unknown>,
+  ): this {
     this.assertLabel(label);
     this.assertEntity(entity, `writeRecipe.${label}.entity`);
     this.steps.push({ kind: "delete", label, entity, mapKey });
@@ -318,7 +340,9 @@ export class WriteRecipeBuilder<E extends EntityMap> {
 
   recipe(name: string, fn: (b: WriteRecipeStepBuilder<E>) => WriteRecipeStepBuilder<E>): this {
     if (this.names.has(name)) {
-      throw new ValidationError([{ path: `writeRecipe.${name}`, message: "Duplicate recipe name" }]);
+      throw new ValidationError([
+        { path: `writeRecipe.${name}`, message: "Duplicate recipe name" },
+      ]);
     }
     this.names.add(name);
     this.recipes.push({ name, steps: fn(new WriteRecipeStepBuilder(this.entities)).build() });
@@ -352,7 +376,11 @@ export function createWriteRecipes<E extends EntityMap>(
   return fn(new WriteRecipeBuilder(entities)).build();
 }
 
-function assertPatternExists(repo: Record<string, unknown>, patternName: string, path: string): void {
+function assertPatternExists(
+  repo: Record<string, unknown>,
+  patternName: string,
+  path: string,
+): void {
   const findObj = repo.find as Record<string, unknown> | undefined;
   const maybeFn = findObj?.[patternName];
   if (typeof maybeFn !== "function") {
@@ -360,33 +388,50 @@ function assertPatternExists(repo: Record<string, unknown>, patternName: string,
   }
 }
 
-export function applyRelations(
-  dbOut: Record<string, unknown>,
-  rels: RelationsConfig,
-): void {
+export function applyRelations(dbOut: Record<string, unknown>, rels: RelationsConfig): void {
   for (const rel of rels) {
     if (rel.kind === "hasMany") {
       const rootRepo = dbOut[rel.root] as Record<string, unknown> | undefined;
       const targetRepo = dbOut[rel.target] as Record<string, unknown> | undefined;
       if (!rootRepo || !targetRepo) {
-        throw new ValidationError([{ path: `relations.${rel.root}.${rel.alias}`, message: `Unknown relation entity reference "${rel.root}" or "${rel.target}"` }]);
+        throw new ValidationError([
+          {
+            path: `relations.${rel.root}.${rel.alias}`,
+            message: `Unknown relation entity reference "${rel.root}" or "${rel.target}"`,
+          },
+        ]);
       }
       if (rootRepo[rel.alias] !== undefined) {
-        throw new ValidationError([{ path: `relations.${rel.root}.${rel.alias}`, message: "Alias collision on root namespace" }]);
+        throw new ValidationError([
+          {
+            path: `relations.${rel.root}.${rel.alias}`,
+            message: "Alias collision on root namespace",
+          },
+        ]);
       }
-      assertPatternExists(targetRepo, rel.listPattern, `relations.${rel.root}.${rel.alias}.listPattern`);
-      const listFn = (targetRepo.find as Record<string, (input: Record<string, unknown>) => Promise<unknown>>)[rel.listPattern]!;
+      assertPatternExists(
+        targetRepo,
+        rel.listPattern,
+        `relations.${rel.root}.${rel.alias}.listPattern`,
+      );
+      const listFn = (
+        targetRepo.find as Record<string, (input: Record<string, unknown>) => Promise<unknown>>
+      )[rel.listPattern]!;
       rootRepo[rel.alias] = {
         list: (input: Record<string, unknown>) => listFn(input),
         add:
           typeof targetRepo.create === "function" && rel.mapCreate
             ? (input: Record<string, unknown>) =>
-                (targetRepo.create as (input: Record<string, unknown>) => Promise<unknown>)(rel.mapCreate!(input))
+                (targetRepo.create as (input: Record<string, unknown>) => Promise<unknown>)(
+                  rel.mapCreate!(input),
+                )
             : undefined,
         create:
           typeof targetRepo.create === "function" && rel.mapCreate
             ? (input: Record<string, unknown>) =>
-                (targetRepo.create as (input: Record<string, unknown>) => Promise<unknown>)(rel.mapCreate!(input))
+                (targetRepo.create as (input: Record<string, unknown>) => Promise<unknown>)(
+                  rel.mapCreate!(input),
+                )
             : undefined,
       };
       continue;
@@ -396,16 +441,28 @@ export function applyRelations(
       const sourceRepo = dbOut[rel.source] as Record<string, unknown> | undefined;
       const targetRepo = dbOut[rel.target] as Record<string, unknown> | undefined;
       if (!sourceRepo || !targetRepo) {
-        throw new ValidationError([{ path: `relations.${rel.source}.${rel.alias}`, message: `Unknown relation entity reference "${rel.source}" or "${rel.target}"` }]);
+        throw new ValidationError([
+          {
+            path: `relations.${rel.source}.${rel.alias}`,
+            message: `Unknown relation entity reference "${rel.source}" or "${rel.target}"`,
+          },
+        ]);
       }
       if (sourceRepo[rel.alias] !== undefined) {
-        throw new ValidationError([{ path: `relations.${rel.source}.${rel.alias}`, message: "Alias collision on source namespace" }]);
+        throw new ValidationError([
+          {
+            path: `relations.${rel.source}.${rel.alias}`,
+            message: "Alias collision on source namespace",
+          },
+        ]);
       }
       sourceRepo[rel.alias] = {
         get:
           typeof targetRepo.get === "function"
             ? (input: Record<string, unknown>) =>
-                (targetRepo.get as (input: Record<string, unknown>) => Promise<unknown>)(rel.mapGet(input))
+                (targetRepo.get as (input: Record<string, unknown>) => Promise<unknown>)(
+                  rel.mapGet(input),
+                )
             : undefined,
       };
       continue;
@@ -416,28 +473,46 @@ export function applyRelations(
     const targetRepo = dbOut[rel.target] as Record<string, unknown> | undefined;
     if (!rootRepo || !throughRepo || !targetRepo) {
       throw new ValidationError([
-        { path: `relations.${rel.root}.${rel.alias}`, message: `Unknown relation entity reference "${rel.root}", "${rel.through}", or "${rel.target}"` },
+        {
+          path: `relations.${rel.root}.${rel.alias}`,
+          message: `Unknown relation entity reference "${rel.root}", "${rel.through}", or "${rel.target}"`,
+        },
       ]);
     }
     if (rootRepo[rel.alias] !== undefined) {
-      throw new ValidationError([{ path: `relations.${rel.root}.${rel.alias}`, message: "Alias collision on root namespace" }]);
+      throw new ValidationError([
+        {
+          path: `relations.${rel.root}.${rel.alias}`,
+          message: "Alias collision on root namespace",
+        },
+      ]);
     }
-    assertPatternExists(throughRepo, rel.listPattern, `relations.${rel.root}.${rel.alias}.listPattern`);
-    const listFn = (throughRepo.find as Record<string, (input: Record<string, unknown>) => Promise<unknown>>)[rel.listPattern]!;
+    assertPatternExists(
+      throughRepo,
+      rel.listPattern,
+      `relations.${rel.root}.${rel.alias}.listPattern`,
+    );
+    const listFn = (
+      throughRepo.find as Record<string, (input: Record<string, unknown>) => Promise<unknown>>
+    )[rel.listPattern]!;
     rootRepo[rel.alias] = {
       list: (input: Record<string, unknown>) => listFn(input),
       listTargets: async (input: Record<string, unknown>) => {
         const throughPage = (await listFn(input)) as { items?: readonly Record<string, unknown>[] };
         const keys = (throughPage.items ?? []).map((it) => rel.mapTargetKey(it));
         if (typeof targetRepo.batchGet === "function") {
-          return (targetRepo.batchGet as (keys: readonly Record<string, unknown>[]) => Promise<unknown>)(keys);
+          return (
+            targetRepo.batchGet as (keys: readonly Record<string, unknown>[]) => Promise<unknown>
+          )(keys);
         }
         return [];
       },
       add:
         typeof throughRepo.create === "function" && rel.mapAdd
           ? (input: Record<string, unknown>) =>
-              (throughRepo.create as (input: Record<string, unknown>) => Promise<unknown>)(rel.mapAdd!(input))
+              (throughRepo.create as (input: Record<string, unknown>) => Promise<unknown>)(
+                rel.mapAdd!(input),
+              )
           : undefined,
     };
   }

--- a/packages/core/src/repository.ts
+++ b/packages/core/src/repository.ts
@@ -13,7 +13,12 @@ import {
 } from "./errors.js";
 import { isConditionalCheckFailed } from "./aws-error.js";
 import { validateAndApplyDefaults } from "./validation.js";
-import { buildPrimaryKeyMap, logicalToStored, storedToLogicalPublic, DISCRIMINATOR_ATTR } from "./entity-runtime.js";
+import {
+  buildPrimaryKeyMap,
+  logicalToStored,
+  storedToLogicalPublic,
+  DISCRIMINATOR_ATTR,
+} from "./entity-runtime.js";
 import type { EntityRuntime } from "./entity-runtime.js";
 import { explainDeleteItem, explainGetItem, emptyCompiled } from "./explain-helpers.js";
 import { createUpdateBuilder, createConditionShape } from "./update.js";
@@ -22,7 +27,10 @@ import { BATCH_GET_MAX_KEYS, BATCH_WRITE_MAX_OPS, chunkArray, sleep } from "./ba
 const DEFAULT_BATCH_ATTEMPTS = 6;
 const DEFAULT_COUNT_MAX_PAGES = 1000;
 
-function mapStoredToItem(runtime: EntityRuntime, stored: Record<string, unknown>): Record<string, unknown> {
+function mapStoredToItem(
+  runtime: EntityRuntime,
+  stored: Record<string, unknown>,
+): Record<string, unknown> {
   return storedToLogicalPublic(stored, runtime.table, new Set(Object.keys(runtime.schema)));
 }
 
@@ -57,7 +65,11 @@ export function createRepository(runtime: EntityRuntime, adapter: DynamoAdapter)
       const out = await adapter.putItem({
         tableName,
         item,
-        ...(mode === "old" ? { returnValues: "ALL_OLD" as const } : mode === "none" ? { returnValues: "NONE" as const } : {}),
+        ...(mode === "old"
+          ? { returnValues: "ALL_OLD" as const }
+          : mode === "none"
+            ? { returnValues: "NONE" as const }
+            : {}),
       });
       if (mode === "none") return undefined;
       if (mode === "old") {
@@ -67,7 +79,8 @@ export function createRepository(runtime: EntityRuntime, adapter: DynamoAdapter)
       const attrs = out.attributes ?? item;
       return mapStoredToItem(runtime, attrs);
     } catch (e) {
-      if (isConditionalCheckFailed(e)) throw new ConditionFailedError("Conditional check failed on create", e);
+      if (isConditionalCheckFailed(e))
+        throw new ConditionFailedError("Conditional check failed on create", e);
       throw e;
     }
   }
@@ -85,7 +98,11 @@ export function createRepository(runtime: EntityRuntime, adapter: DynamoAdapter)
         item,
         conditionExpression: "attribute_not_exists(#pk)",
         expressionAttributeNames: { "#pk": runtime.table.partitionKey },
-        ...(mode === "old" ? { returnValues: "ALL_OLD" as const } : mode === "none" ? { returnValues: "NONE" as const } : {}),
+        ...(mode === "old"
+          ? { returnValues: "ALL_OLD" as const }
+          : mode === "none"
+            ? { returnValues: "NONE" as const }
+            : {}),
       });
       if (mode === "none") return undefined;
       if (mode === "old") {
@@ -96,7 +113,11 @@ export function createRepository(runtime: EntityRuntime, adapter: DynamoAdapter)
       return mapStoredToItem(runtime, attrs);
     } catch (e) {
       if (isConditionalCheckFailed(e)) {
-        throw new ItemAlreadyExistsError(`Item already exists for entity "${runtime.entityName}"`, runtime.entityName, e);
+        throw new ItemAlreadyExistsError(
+          `Item already exists for entity "${runtime.entityName}"`,
+          runtime.entityName,
+          e,
+        );
       }
       throw e;
     }
@@ -127,7 +148,8 @@ export function createRepository(runtime: EntityRuntime, adapter: DynamoAdapter)
       }
       return undefined;
     } catch (e) {
-      if (isConditionalCheckFailed(e)) throw new ConditionFailedError("Conditional check failed on delete", e);
+      if (isConditionalCheckFailed(e))
+        throw new ConditionFailedError("Conditional check failed on delete", e);
       throw e;
     }
   }
@@ -176,11 +198,15 @@ export function createRepository(runtime: EntityRuntime, adapter: DynamoAdapter)
       exclusiveStartKey = out.lastEvaluatedKey;
       if (!exclusiveStartKey) break;
     }
-    if (plan.returnConsumedCapacity) return { count: total, consumedCapacity: { capacityUnits: totalCapacity } };
+    if (plan.returnConsumedCapacity)
+      return { count: total, consumedCapacity: { capacityUnits: totalCapacity } };
     return total;
   }
 
-  async function runPattern(pattern: AccessPatternDef, input: Record<string, unknown>): Promise<unknown> {
+  async function runPattern(
+    pattern: AccessPatternDef,
+    input: Record<string, unknown>,
+  ): Promise<unknown> {
     const plan = pattern.buildRequest(input);
     if (plan.type === "GetItem") {
       const raw = await adapter.getItem({
@@ -285,7 +311,10 @@ export function createRepository(runtime: EntityRuntime, adapter: DynamoAdapter)
     return w;
   }
 
-  function explainPattern(pattern: AccessPatternDef, input: Record<string, unknown>): CompiledOperation {
+  function explainPattern(
+    pattern: AccessPatternDef,
+    input: Record<string, unknown>,
+  ): CompiledOperation {
     const plan = pattern.buildRequest(input);
     if (plan.type === "GetItem") {
       return {
@@ -346,7 +375,9 @@ export function createRepository(runtime: EntityRuntime, adapter: DynamoAdapter)
     };
   }
 
-  async function batchGet(keys: readonly Record<string, unknown>[]): Promise<(Record<string, unknown> | null)[]> {
+  async function batchGet(
+    keys: readonly Record<string, unknown>[],
+  ): Promise<(Record<string, unknown> | null)[]> {
     if (keys.length === 0) return [];
     const preparedKeys = keys.map((k) => buildPrimaryKeyMap(runtime, k));
     const slots: (Record<string, unknown> | null)[] = new Array(keys.length).fill(null);
@@ -379,7 +410,10 @@ export function createRepository(runtime: EntityRuntime, adapter: DynamoAdapter)
       }
     };
 
-    const chunks = chunkArray(preparedKeys.map((k, i) => ({ k, i })), BATCH_GET_MAX_KEYS);
+    const chunks = chunkArray(
+      preparedKeys.map((k, i) => ({ k, i })),
+      BATCH_GET_MAX_KEYS,
+    );
     for (const metaChunk of chunks) {
       let pending = metaChunk;
       for (let attempt = 0; attempt < DEFAULT_BATCH_ATTEMPTS; attempt++) {
@@ -404,7 +438,10 @@ export function createRepository(runtime: EntityRuntime, adapter: DynamoAdapter)
     | { readonly kind: "put"; readonly item: Record<string, unknown> }
     | { readonly kind: "delete"; readonly key: Record<string, unknown> };
 
-  async function batchWrite(req: { puts?: readonly Record<string, unknown>[]; deletes?: readonly Record<string, unknown>[] }): Promise<void> {
+  async function batchWrite(req: {
+    puts?: readonly Record<string, unknown>[];
+    deletes?: readonly Record<string, unknown>[];
+  }): Promise<void> {
     const ops: BatchOp[] = [];
     for (const p of req.puts ?? []) {
       const prepared = validateAndApplyDefaults({ ...p }, runtime.schema, runtime.fieldMeta);
@@ -450,7 +487,10 @@ export function createRepository(runtime: EntityRuntime, adapter: DynamoAdapter)
     }));
   }
 
-  function explainBatchWrite(req: { puts?: readonly Record<string, unknown>[]; deletes?: readonly Record<string, unknown>[] }): BatchChunkPlan[] {
+  function explainBatchWrite(req: {
+    puts?: readonly Record<string, unknown>[];
+    deletes?: readonly Record<string, unknown>[];
+  }): BatchChunkPlan[] {
     const ops: BatchOp[] = [];
     for (const p of req.puts ?? []) {
       const prepared = validateAndApplyDefaults({ ...p }, runtime.schema, runtime.fieldMeta);
@@ -460,7 +500,9 @@ export function createRepository(runtime: EntityRuntime, adapter: DynamoAdapter)
       ops.push({ kind: "delete", key: buildPrimaryKeyMap(runtime, d) });
     }
     return chunkArray(ops, BATCH_WRITE_MAX_OPS).map((chunk) => {
-      const putItems = chunk.filter((o): o is Extract<BatchOp, { kind: "put" }> => o.kind === "put").map((o) => o.item);
+      const putItems = chunk
+        .filter((o): o is Extract<BatchOp, { kind: "put" }> => o.kind === "put")
+        .map((o) => o.item);
       const deleteKeys = chunk
         .filter((o): o is Extract<BatchOp, { kind: "delete" }> => o.kind === "delete")
         .map((o) => o.key);

--- a/packages/core/src/table.ts
+++ b/packages/core/src/table.ts
@@ -10,16 +10,29 @@ export function defineTable<const T extends TableDef>(def: T): T {
   }
   for (const [name, idx] of lsiEntries) {
     if (idx.partitionKey !== def.partitionKey) {
-      throw new Error(`defineTable: localIndexes.${name} must use the same partitionKey as the base table`);
+      throw new Error(
+        `defineTable: localIndexes.${name} must use the same partitionKey as the base table`,
+      );
     }
     if (!idx.sortKey) {
       throw new Error(`defineTable: localIndexes.${name}.sortKey is required`);
     }
-    if (idx.projectionType === "INCLUDE" && (!idx.nonKeyAttributes || idx.nonKeyAttributes.length === 0)) {
-      throw new Error(`defineTable: localIndexes.${name}.nonKeyAttributes is required when projectionType is INCLUDE`);
+    if (
+      idx.projectionType === "INCLUDE" &&
+      (!idx.nonKeyAttributes || idx.nonKeyAttributes.length === 0)
+    ) {
+      throw new Error(
+        `defineTable: localIndexes.${name}.nonKeyAttributes is required when projectionType is INCLUDE`,
+      );
     }
-    if (idx.projectionType !== "INCLUDE" && idx.nonKeyAttributes && idx.nonKeyAttributes.length > 0) {
-      throw new Error(`defineTable: localIndexes.${name}.nonKeyAttributes is only valid with projectionType INCLUDE`);
+    if (
+      idx.projectionType !== "INCLUDE" &&
+      idx.nonKeyAttributes &&
+      idx.nonKeyAttributes.length > 0
+    ) {
+      throw new Error(
+        `defineTable: localIndexes.${name}.nonKeyAttributes is only valid with projectionType INCLUDE`,
+      );
     }
   }
   return def;

--- a/packages/core/src/transact.ts
+++ b/packages/core/src/transact.ts
@@ -8,7 +8,12 @@ import type { TableDef } from "./types.js";
 import type { CompiledOperation } from "./types.js";
 import type { CompiledEntity } from "./entity.js";
 import type { EntityRuntime } from "./entity-runtime.js";
-import { DISCRIMINATOR_ATTR, buildPrimaryKeyMap, logicalToStored, storedToLogicalPublic } from "./entity-runtime.js";
+import {
+  DISCRIMINATOR_ATTR,
+  buildPrimaryKeyMap,
+  logicalToStored,
+  storedToLogicalPublic,
+} from "./entity-runtime.js";
 import {
   IdempotentParameterMismatchError,
   TransactionCanceledError,
@@ -88,7 +93,9 @@ function assertEntityTable(ent: CompiledEntity, connectTable: TableDef): EntityR
   return r;
 }
 
-function mapAwsReasons(raw: ReturnType<typeof readTransactionCancellationReasons>): TransactionCancellationReason[] {
+function mapAwsReasons(
+  raw: ReturnType<typeof readTransactionCancellationReasons>,
+): TransactionCancellationReason[] {
   return raw.map((r) => ({
     code: r.Code,
     message: r.Message,
@@ -109,7 +116,12 @@ export class TransactWriteBuilder {
   put(
     ent: CompiledEntity,
     input: Record<string, unknown>,
-    options?: { if?: (fields: Record<string, FieldRef<unknown>>, op: typeof conditionOpsImpl) => ConditionExpr },
+    options?: {
+      if?: (
+        fields: Record<string, FieldRef<unknown>>,
+        op: typeof conditionOpsImpl,
+      ) => ConditionExpr;
+    },
   ): void {
     const runtime = assertEntityTable(ent, this.connectTable);
     const prepared = validateAndApplyDefaults({ ...input }, runtime.schema, runtime.fieldMeta);
@@ -148,7 +160,12 @@ export class TransactWriteBuilder {
 
   update(ent: CompiledEntity, primaryLogical: Record<string, unknown>) {
     const runtime = assertEntityTable(ent, this.connectTable);
-    const inst = createUpdateBuilder(runtime, noopAdapter, primaryLogical, createConditionShape(runtime.fieldMeta));
+    const inst = createUpdateBuilder(
+      runtime,
+      noopAdapter,
+      primaryLogical,
+      createConditionShape(runtime.fieldMeta),
+    );
     this.ops.push(() => {
       const c = inst.compileForTransact();
       const adapterItem: TransactWriteItemInput = {
@@ -168,7 +185,12 @@ export class TransactWriteBuilder {
   delete(
     ent: CompiledEntity,
     keyLogical: Record<string, unknown>,
-    options?: { if?: (fields: Record<string, FieldRef<unknown>>, op: typeof conditionOpsImpl) => ConditionExpr },
+    options?: {
+      if?: (
+        fields: Record<string, FieldRef<unknown>>,
+        op: typeof conditionOpsImpl,
+      ) => ConditionExpr;
+    },
   ): void {
     const runtime = assertEntityTable(ent, this.connectTable);
     const key = buildPrimaryKeyMap(runtime, keyLogical);
@@ -238,7 +260,9 @@ export class TransactWriteBuilder {
     const items = finalized.map((x) => x.adapterItem);
     const explainPlans = finalized.map((x) => x.explain);
     if (items.length === 0) {
-      throw new ValidationError([{ path: "tx.write", message: "Transaction has no write participants" }]);
+      throw new ValidationError([
+        { path: "tx.write", message: "Transaction has no write participants" },
+      ]);
     }
     if (items.length > TRANSACT_MAX_ITEMS) {
       throw new ValidationError([
@@ -257,7 +281,8 @@ export class TransactWriteBuilder {
         throw new ValidationError([
           {
             path: "tx.write",
-            message: "TransactWriteItems cannot target the same item more than once (duplicate key across Put/Update/Delete/ConditionCheck)",
+            message:
+              "TransactWriteItems cannot target the same item more than once (duplicate key across Put/Update/Delete/ConditionCheck)",
           },
         ]);
       }
@@ -299,7 +324,9 @@ export class TransactReadBuilder {
     options?: { consistentRead?: boolean },
   ): void {
     if (this.labels.has(label)) {
-      throw new ValidationError([{ path: `tx.read.get(${label})`, message: "Duplicate label in transact read" }]);
+      throw new ValidationError([
+        { path: `tx.read.get(${label})`, message: "Duplicate label in transact read" },
+      ]);
     }
     this.labels.add(label);
     const runtime = assertEntityTable(ent, this.connectTable);
@@ -314,7 +341,9 @@ export class TransactReadBuilder {
       consistentRead: s.consistentRead,
     }));
     if (items.length === 0) {
-      throw new ValidationError([{ path: "tx.read", message: "Transaction has no read participants" }]);
+      throw new ValidationError([
+        { path: "tx.read", message: "Transaction has no read participants" },
+      ]);
     }
     if (items.length > TRANSACT_MAX_ITEMS) {
       throw new ValidationError([
@@ -357,7 +386,11 @@ export class TransactReadBuilder {
         out[slot.label] = null;
         continue;
       }
-      out[slot.label] = storedToLogicalPublic(raw, slot.runtime.table, new Set(Object.keys(slot.runtime.schema)));
+      out[slot.label] = storedToLogicalPublic(
+        raw,
+        slot.runtime.table,
+        new Set(Object.keys(slot.runtime.schema)),
+      );
     }
     return out;
   }
@@ -377,12 +410,18 @@ function handleTransactError(e: unknown): never {
 export function createTransactServices(connectTable: TableDef, adapter: DynamoAdapter) {
   return {
     tx: {
-      write: async (fn: (w: TransactWriteBuilder) => void | Promise<void>, options?: { clientRequestToken?: string }) => {
+      write: async (
+        fn: (w: TransactWriteBuilder) => void | Promise<void>,
+        options?: { clientRequestToken?: string },
+      ) => {
         const b = new TransactWriteBuilder(connectTable);
         await fn(b);
         const { items } = b.finalize();
         try {
-          await adapter.transactWriteItems({ items, clientRequestToken: options?.clientRequestToken });
+          await adapter.transactWriteItems({
+            items,
+            clientRequestToken: options?.clientRequestToken,
+          });
         } catch (e) {
           handleTransactError(e);
         }

--- a/packages/core/src/update.ts
+++ b/packages/core/src/update.ts
@@ -146,8 +146,19 @@ export function compileConditionExpression(expr: ConditionExpr): {
   const nameCounter = { i: 0 };
   const valCounter = { i: 0 };
   const pathToName = new Map<string, string>();
-  const conditionExpression = compileCond(expr as unknown as CondNode, nameCounter, valCounter, pathToName, names, values);
-  return { conditionExpression, expressionAttributeNames: names, expressionAttributeValues: values };
+  const conditionExpression = compileCond(
+    expr as unknown as CondNode,
+    nameCounter,
+    valCounter,
+    pathToName,
+    names,
+    values,
+  );
+  return {
+    conditionExpression,
+    expressionAttributeNames: names,
+    expressionAttributeValues: values,
+  };
 }
 
 export const conditionOpsImpl = {
@@ -180,7 +191,9 @@ export const conditionOpsImpl = {
   },
 };
 
-export function createConditionShape(fieldMeta: Record<string, FieldMeta>): Record<string, FieldRef<unknown>> {
+export function createConditionShape(
+  fieldMeta: Record<string, FieldMeta>,
+): Record<string, FieldRef<unknown>> {
   const shape: Record<string, FieldRef<unknown>> = {};
   for (const k of Object.keys(fieldMeta)) {
     const meta = fieldMeta[k];
@@ -285,7 +298,10 @@ export class UpdateBuilderInstance {
   }
 
   setAdd(path: string | FieldRef<unknown>, members: Set<unknown>): this {
-    if (members.size === 0) throw new ValidationError([{ path: typeof path === "string" ? path : path.path, message: "Empty set is not allowed" }]);
+    if (members.size === 0)
+      throw new ValidationError([
+        { path: typeof path === "string" ? path : path.path, message: "Empty set is not allowed" },
+      ]);
     const p = typeof path === "string" ? path : path.path;
     this.assertKnownPathRoot(p, "setAdd");
     this.setAddOps.push({ path: p, members });
@@ -293,21 +309,30 @@ export class UpdateBuilderInstance {
   }
 
   setDelete(path: string | FieldRef<unknown>, members: Set<unknown>): this {
-    if (members.size === 0) throw new ValidationError([{ path: typeof path === "string" ? path : path.path, message: "Empty set is not allowed" }]);
+    if (members.size === 0)
+      throw new ValidationError([
+        { path: typeof path === "string" ? path : path.path, message: "Empty set is not allowed" },
+      ]);
     const p = typeof path === "string" ? path : path.path;
     this.assertKnownPathRoot(p, "setDelete");
     this.setDeleteOps.push({ path: p, members });
     return this;
   }
 
-  if(fn: (fields: Record<string, FieldRef<unknown>>, op: typeof conditionOpsImpl) => ConditionExpr): this {
+  if(
+    fn: (fields: Record<string, FieldRef<unknown>>, op: typeof conditionOpsImpl) => ConditionExpr,
+  ): this {
     this.userCond = fn(this.conditionShape, conditionOpsImpl) as unknown as CondNode;
     return this;
   }
 
   explain(): CompiledOperation {
-    const { updateExpression, expressionAttributeNames, expressionAttributeValues, conditionExpression } =
-      this.compileExpressions();
+    const {
+      updateExpression,
+      expressionAttributeNames,
+      expressionAttributeValues,
+      conditionExpression,
+    } = this.compileExpressions();
     const key = buildPrimaryKeyMap(this.runtime, this.primaryLogical);
     return {
       ...emptyCompiled(this.runtime.entityName, "UpdateItem", this.runtime.table.name),
@@ -329,8 +354,12 @@ export class UpdateBuilderInstance {
     readonly expressionAttributeValues: Record<string, unknown>;
     readonly conditionExpression?: string;
   } {
-    const { updateExpression, expressionAttributeNames, expressionAttributeValues, conditionExpression } =
-      this.compileExpressions();
+    const {
+      updateExpression,
+      expressionAttributeNames,
+      expressionAttributeValues,
+      conditionExpression,
+    } = this.compileExpressions();
     const key = buildPrimaryKeyMap(this.runtime, this.primaryLogical);
     return {
       tableName: this.runtime.table.name,
@@ -346,8 +375,12 @@ export class UpdateBuilderInstance {
     return?: "new" | "old" | "none" | "updatedNew" | "updatedOld";
     returnValuesOnConditionCheckFailure?: "old" | "none";
   }): Promise<Record<string, unknown> | undefined> {
-    const { updateExpression, expressionAttributeNames, expressionAttributeValues, conditionExpression } =
-      this.compileExpressions();
+    const {
+      updateExpression,
+      expressionAttributeNames,
+      expressionAttributeValues,
+      conditionExpression,
+    } = this.compileExpressions();
     const key = buildPrimaryKeyMap(this.runtime, this.primaryLogical);
     const ret = options?.return ?? "new";
     const rv =
@@ -381,9 +414,14 @@ export class UpdateBuilderInstance {
       if (!out) {
         throw new Error("UpdateItem returned no attributes for the requested return mode");
       }
-      return storedToLogicalPublic(out, this.runtime.table, new Set(Object.keys(this.runtime.schema)));
+      return storedToLogicalPublic(
+        out,
+        this.runtime.table,
+        new Set(Object.keys(this.runtime.schema)),
+      );
     } catch (e) {
-      if (isConditionalCheckFailed(e)) throw new ConditionFailedError("Conditional check failed", e);
+      if (isConditionalCheckFailed(e))
+        throw new ConditionFailedError("Conditional check failed", e);
       throw e;
     }
   }

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -2,12 +2,12 @@ import { ValidationError } from "./errors.js";
 import type { FieldMeta } from "./types.js";
 import type { FieldDef, SchemaRecord } from "./fields.js";
 
-const ISO_DATETIME_RE =
-  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})$/;
+const ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})$/;
 
 function isJsonSerializable(value: unknown): boolean {
   if (value === undefined) return false;
-  if (typeof value === "function" || typeof value === "symbol" || typeof value === "bigint") return false;
+  if (typeof value === "function" || typeof value === "symbol" || typeof value === "bigint")
+    return false;
   try {
     JSON.stringify(value);
     return true;
@@ -42,7 +42,10 @@ function validateByFieldDef(
     issues.push({ path, message: "Expected string (ISO datetime)" });
     return;
   }
-  if (def._kind === "datetime" && (typeof value !== "string" || !ISO_DATETIME_RE.test(value) || Number.isNaN(Date.parse(value)))) {
+  if (
+    def._kind === "datetime" &&
+    (typeof value !== "string" || !ISO_DATETIME_RE.test(value) || Number.isNaN(Date.parse(value)))
+  ) {
     issues.push({ path, message: "Expected ISO-8601 datetime string" });
     return;
   }
@@ -57,13 +60,23 @@ function validateByFieldDef(
     return;
   }
   if (def._kind === "ttl") {
-    if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+    if (
+      typeof value !== "number" ||
+      !Number.isFinite(value) ||
+      !Number.isInteger(value) ||
+      value < 0
+    ) {
       issues.push({ path, message: "Expected TTL epoch seconds as a non-negative integer number" });
     }
     return;
   }
   if (def._kind === "object") {
-    if (typeof value !== "object" || value === null || Array.isArray(value) || value instanceof Set) {
+    if (
+      typeof value !== "object" ||
+      value === null ||
+      Array.isArray(value) ||
+      value instanceof Set
+    ) {
       issues.push({ path, message: "Expected object" });
       return;
     }
@@ -76,7 +89,8 @@ function validateByFieldDef(
       const child = shape[k]!;
       const childVal = obj[k];
       if (childVal === undefined) {
-        if (child._required) issues.push({ path: `${path}.${k}`, message: "Required field missing" });
+        if (child._required)
+          issues.push({ path: `${path}.${k}`, message: "Required field missing" });
         continue;
       }
       validateByFieldDef(child, childVal, `${path}.${k}`, issues);
@@ -84,7 +98,12 @@ function validateByFieldDef(
     return;
   }
   if (def._kind === "record") {
-    if (typeof value !== "object" || value === null || Array.isArray(value) || value instanceof Set) {
+    if (
+      typeof value !== "object" ||
+      value === null ||
+      Array.isArray(value) ||
+      value instanceof Set
+    ) {
       issues.push({ path, message: "Expected record object" });
       return;
     }
@@ -134,7 +153,11 @@ function validateByFieldDef(
   }
 }
 
-export function assertStrictKeys(input: Record<string, unknown>, allowed: Set<string>, context: string): void {
+export function assertStrictKeys(
+  input: Record<string, unknown>,
+  allowed: Set<string>,
+  context: string,
+): void {
   const issues: { path: string; message: string }[] = [];
   for (const k of Object.keys(input)) {
     if (!allowed.has(k)) {

--- a/packages/core/test/complex-attributes.test.ts
+++ b/packages/core/test/complex-attributes.test.ts
@@ -36,7 +36,10 @@ const Profile = entity("Profile", {
   .keys(({ profileId }: ProfileKeyInput) => ({ pk: key("PROFILE", profileId), sk: key("ROOT") }))
   .identity(["profileId"])
   .accessPatterns((ap) => ({
-    byId: ap.get(({ profileId }: ProfileKeyInput) => ({ pk: key("PROFILE", profileId), sk: key("ROOT") })),
+    byId: ap.get(({ profileId }: ProfileKeyInput) => ({
+      pk: key("PROFILE", profileId),
+      sk: key("ROOT"),
+    })),
   }));
 
 describe("complex attributes", () => {
@@ -76,7 +79,12 @@ describe("complex attributes", () => {
       .setAdd("labels", new Set(["gamma"]))
       .setDelete("labels", new Set(["alpha"]))
       .removePath(["settings.locale"])
-      .if((f, o) => o.and(o.contains(pathRef(f.tags!, 0), "z"), o.beginsWith(pathRef(f.settings!, "theme"), "li")))
+      .if((f, o) =>
+        o.and(
+          o.contains(pathRef(f.tags!, 0), "z"),
+          o.beginsWith(pathRef(f.settings!, "theme"), "li"),
+        ),
+      )
       .explain();
     expect(op.updateExpression).toContain("list_append");
     expect(op.updateExpression).toContain("DELETE");

--- a/packages/core/test/entity.integration.test.ts
+++ b/packages/core/test/entity.integration.test.ts
@@ -1,13 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  connect,
-  defineTable,
-  entity,
-  enumType,
-  id,
-  key,
-  string,
-} from "../src/index.js";
+import { connect, defineTable, entity, enumType, id, key, string } from "../src/index.js";
 import { createMemoryAdapter } from "./mock-adapter.js";
 
 const AppTable = defineTable({

--- a/packages/core/test/lifecycle-ttl.test.ts
+++ b/packages/core/test/lifecycle-ttl.test.ts
@@ -67,16 +67,25 @@ describe("v0.8 ttl + lifecycle", () => {
   });
 
   it("supports archive recipe with source delete", async () => {
-    const db = connect(AppTable, { adapter: createMemoryAdapter(), entities: { User, UserArchive } });
+    const db = connect(AppTable, {
+      adapter: createMemoryAdapter(),
+      entities: { User, UserArchive },
+    });
     await db.User.create({ userId: "usr_3" as never, email: "c@example.com" });
     await db.lifecycle?.archive({
       sourceEntity: User,
       sourceKey: { userId: "usr_3" as never },
       archiveEntity: UserArchive,
-      archiveItem: { archiveId: "arc_1" as never, userId: "usr_3" as never, email: "c@example.com" },
+      archiveItem: {
+        archiveId: "arc_1" as never,
+        userId: "usr_3" as never,
+        email: "c@example.com",
+      },
       sourceDisposition: "delete",
     });
     expect(await db.User.get({ userId: "usr_3" as never })).toBeNull();
-    expect(await db.UserArchive.get({ archiveId: "arc_1" as never })).toMatchObject({ userId: "usr_3" });
+    expect(await db.UserArchive.get({ archiveId: "arc_1" as never })).toMatchObject({
+      userId: "usr_3",
+    });
   });
 });

--- a/packages/core/test/mock-adapter.ts
+++ b/packages/core/test/mock-adapter.ts
@@ -77,10 +77,15 @@ function resolveSkAttr(input: QueryInput): string | undefined {
   return undefined;
 }
 
-function cloneAllTables(byTable: Map<string, Record<string, unknown>[]>): Map<string, Record<string, unknown>[]> {
+function cloneAllTables(
+  byTable: Map<string, Record<string, unknown>[]>,
+): Map<string, Record<string, unknown>[]> {
   const out = new Map<string, Record<string, unknown>[]>();
   for (const [t, rows] of byTable) {
-    out.set(t, rows.map((r) => ({ ...r })));
+    out.set(
+      t,
+      rows.map((r) => ({ ...r })),
+    );
   }
   return out;
 }
@@ -101,14 +106,19 @@ function applyMockUpdateFromTransact(
     const nameAlias = m[1]!;
     const valAlias = m[2]!;
     const attrName = it.expressionAttributeNames[nameAlias];
-    if (attrName != null && Object.prototype.hasOwnProperty.call(it.expressionAttributeValues, valAlias)) {
+    if (
+      attrName != null &&
+      Object.prototype.hasOwnProperty.call(it.expressionAttributeValues, valAlias)
+    ) {
       hit[attrName] = it.expressionAttributeValues[valAlias];
     }
   }
 }
 
 /** In-memory mock assuming base-table keys `pk` and `sk` (matches typical defineTable examples). */
-export function createMemoryAdapter(): DynamoAdapter & { allItems(table: string): Record<string, unknown>[] } {
+export function createMemoryAdapter(): DynamoAdapter & {
+  allItems(table: string): Record<string, unknown>[];
+} {
   const byTable = new Map<string, Record<string, unknown>[]>();
 
   function list(table: string): Record<string, unknown>[] {
@@ -166,7 +176,9 @@ export function createMemoryAdapter(): DynamoAdapter & { allItems(table: string)
         filtered = filtered.filter((it) => skMatches(it, input, skAttr, pre, "begins"));
       }
       if (skAttr && input.expressionAttributeValues[":skeq"] !== undefined) {
-        filtered = filtered.filter((it) => skMatches(it, input, skAttr, input.expressionAttributeValues[":skeq"], "eq"));
+        filtered = filtered.filter((it) =>
+          skMatches(it, input, skAttr, input.expressionAttributeValues[":skeq"], "eq"),
+        );
       }
       if (skAttr && input.expressionAttributeValues[":sklo"] !== undefined) {
         filtered = filtered.filter((it) =>
@@ -179,9 +191,17 @@ export function createMemoryAdapter(): DynamoAdapter & { allItems(table: string)
       const lim = input.limit ?? filtered.length;
       const page = filtered.slice(0, lim);
       if (input.select === "COUNT") {
-        return { items: [], count: page.length, lastEvaluatedKey: undefined, consumedCapacity: { capacityUnits: page.length } };
+        return {
+          items: [],
+          count: page.length,
+          lastEvaluatedKey: undefined,
+          consumedCapacity: { capacityUnits: page.length },
+        };
       }
-      return { items: page.map((x) => ({ ...x })), consumedCapacity: { capacityUnits: page.length } };
+      return {
+        items: page.map((x) => ({ ...x })),
+        consumedCapacity: { capacityUnits: page.length },
+      };
     },
     async scan(input: ScanInput): Promise<ScanOutput> {
       let filtered = list(input.tableName);
@@ -269,7 +289,10 @@ export function createMemoryAdapter(): DynamoAdapter & { allItems(table: string)
   };
 }
 
-function pickKey(item: Record<string, unknown>, key: Record<string, unknown>): Record<string, unknown> {
+function pickKey(
+  item: Record<string, unknown>,
+  key: Record<string, unknown>,
+): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const k of Object.keys(key)) out[k] = item[k];
   return out;

--- a/packages/core/test/put-vs-create.test.ts
+++ b/packages/core/test/put-vs-create.test.ts
@@ -20,7 +20,10 @@ const User = entity("User", {
   .keys(({ userId }: { userId: string }) => ({ pk: key("USER", userId), sk: key("ROOT") }))
   .identity(["userId"])
   .accessPatterns((ap) => ({
-    byId: ap.get(({ userId }: { userId: string }) => ({ pk: key("USER", userId), sk: key("ROOT") })),
+    byId: ap.get(({ userId }: { userId: string }) => ({
+      pk: key("USER", userId),
+      sk: key("ROOT"),
+    })),
   }));
 
 describe("repository put vs create", () => {

--- a/packages/core/test/relations.test.ts
+++ b/packages/core/test/relations.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { connect, defineTable, entity, enumType, id, key, string, ValidationError } from "../src/index.js";
+import {
+  connect,
+  defineTable,
+  entity,
+  enumType,
+  id,
+  key,
+  string,
+  ValidationError,
+} from "../src/index.js";
 import { createMemoryAdapter } from "./mock-adapter.js";
 
 const AppTable = defineTable({
@@ -47,11 +56,20 @@ const Membership = entity("Membership", {
   role: enumType(["owner", "admin", "member"] as const).required(),
 })
   .inTable(AppTable)
-  .keys(({ orgId, userId }: MembershipKeyInput) => ({ pk: key("ORG", orgId), sk: key("MEMBER", userId) }))
-  .index("GSI1", ({ userId }: UserKeyInput) => ({ gsi1pk: key("USER", userId), gsi1sk: key("ORG") }))
+  .keys(({ orgId, userId }: MembershipKeyInput) => ({
+    pk: key("ORG", orgId),
+    sk: key("MEMBER", userId),
+  }))
+  .index("GSI1", ({ userId }: UserKeyInput) => ({
+    gsi1pk: key("USER", userId),
+    gsi1sk: key("ORG"),
+  }))
   .identity(["orgId", "userId"])
   .accessPatterns((ap) => ({
-    byOrg: ap.query(undefined, ({ orgId }: OrgKeyInput) => ({ pk: key("ORG", orgId), skBeginsWith: key("MEMBER") })),
+    byOrg: ap.query(undefined, ({ orgId }: OrgKeyInput) => ({
+      pk: key("ORG", orgId),
+      skBeginsWith: key("MEMBER"),
+    })),
     byOrgAdmins: ap.query(undefined, ({ orgId }: OrgKeyInput) => ({
       pk: key("ORG", orgId),
       skBeginsWith: key("MEMBER"),
@@ -59,7 +77,10 @@ const Membership = entity("Membership", {
       filterExpressionAttributeNames: { "#r": "role" },
       filterExpressionAttributeValues: { ":admin": "admin" },
     })),
-    byUser: ap.query("GSI1", ({ userId }: UserKeyInput) => ({ pk: key("USER", userId), skBeginsWith: key("ORG") })),
+    byUser: ap.query("GSI1", ({ userId }: UserKeyInput) => ({
+      pk: key("USER", userId),
+      skBeginsWith: key("ORG"),
+    })),
   }));
 
 const Folder = entity("Folder", {
@@ -75,7 +96,10 @@ const Folder = entity("Folder", {
   }))
   .identity(["folderId"])
   .accessPatterns((ap) => ({
-    byId: ap.get(({ folderId }: FolderKeyInput) => ({ pk: key("FOLDER", folderId), sk: key("ROOT") })),
+    byId: ap.get(({ folderId }: FolderKeyInput) => ({
+      pk: key("FOLDER", folderId),
+      sk: key("ROOT"),
+    })),
     byParent: ap.query("GSI1", ({ parentId, cursor, limit }: FolderParentPageInput) => ({
       pk: key("PARENT", String(parentId ?? "ROOT")),
       skBeginsWith: key("FOLDER"),
@@ -136,43 +160,73 @@ describe("relations DSL and namespaces", () => {
     await db.Org.create({ orgId: "org_1" as never, name: "Acme" });
     await db.User.create({ userId: "usr_1" as never, email: "u1@example.com" });
 
-    await (db.Org as unknown as { members: { add: (input: Record<string, unknown>) => Promise<unknown> } }).members.add({
+    await (
+      db.Org as unknown as {
+        members: { add: (input: Record<string, unknown>) => Promise<unknown> };
+      }
+    ).members.add({
       orgId: "org_1" as never,
       userId: "usr_1" as never,
       role: "admin",
     });
     const orgMembers = await (
-      db.Org as unknown as { members: { list: (input: Record<string, unknown>) => Promise<{ items: unknown[] }> } }
+      db.Org as unknown as {
+        members: { list: (input: Record<string, unknown>) => Promise<{ items: unknown[] }> };
+      }
     ).members.list({ orgId: "org_1" as never });
     expect(orgMembers.items.length).toBe(1);
     const userOrgs = await (
-      db.User as unknown as { orgs: { listTargets: (input: Record<string, unknown>) => Promise<Record<string, unknown>[]> } }
+      db.User as unknown as {
+        orgs: {
+          listTargets: (input: Record<string, unknown>) => Promise<Record<string, unknown>[]>;
+        };
+      }
     ).orgs.listTargets({ userId: "usr_1" as never });
     expect(userOrgs[0]).toMatchObject({ orgId: "org_1", name: "Acme" });
     const admins = await (
-      db.Org as unknown as { admins: { list: (input: Record<string, unknown>) => Promise<{ items: unknown[] }> } }
+      db.Org as unknown as {
+        admins: { list: (input: Record<string, unknown>) => Promise<{ items: unknown[] }> };
+      }
     ).admins.list({ orgId: "org_1" as never });
     expect(admins.items.length).toBe(1);
 
     const m = (await db.Membership.find.byOrg({ orgId: "org_1" as never })) as { items: unknown[] };
     const parent = await (
-      db.Membership as unknown as { org: { get: (input: Record<string, unknown>) => Promise<unknown> } }
+      db.Membership as unknown as {
+        org: { get: (input: Record<string, unknown>) => Promise<unknown> };
+      }
     ).org.get(m.items[0]! as Record<string, unknown>);
     expect(parent).toMatchObject({ orgId: "org_1" });
 
     await db.Folder.create({ folderId: "fld_root" as never, name: "root" });
-    await db.Folder.create({ folderId: "fld_child_1" as never, parentId: "fld_root" as never, name: "c1" });
-    await db.Folder.create({ folderId: "fld_child_2" as never, parentId: "fld_root" as never, name: "c2" });
+    await db.Folder.create({
+      folderId: "fld_child_1" as never,
+      parentId: "fld_root" as never,
+      name: "c1",
+    });
+    await db.Folder.create({
+      folderId: "fld_child_2" as never,
+      parentId: "fld_root" as never,
+      name: "c2",
+    });
     const childrenPage1 = await (
-      db.Folder as unknown as { children: { list: (input: Record<string, unknown>) => Promise<{ items: unknown[]; cursor?: string }> } }
+      db.Folder as unknown as {
+        children: {
+          list: (input: Record<string, unknown>) => Promise<{ items: unknown[]; cursor?: string }>;
+        };
+      }
     ).children.list({ parentId: "fld_root" as never, limit: 1 });
     expect(childrenPage1.items.length).toBe(1);
     const childrenPage2 = await (
-      db.Folder as unknown as { children: { list: (input: Record<string, unknown>) => Promise<{ items: unknown[] }> } }
+      db.Folder as unknown as {
+        children: { list: (input: Record<string, unknown>) => Promise<{ items: unknown[] }> };
+      }
     ).children.list({ parentId: "fld_root" as never, cursor: childrenPage1.cursor });
     expect(childrenPage2.items.length).toBeGreaterThanOrEqual(1);
     const parentFolder = await (
-      db.Folder as unknown as { parent: { get: (input: Record<string, unknown>) => Promise<unknown> } }
+      db.Folder as unknown as {
+        parent: { get: (input: Record<string, unknown>) => Promise<unknown> };
+      }
     ).parent.get({ parentId: "fld_root" as never });
     expect(parentFolder).toMatchObject({ folderId: "fld_root" });
   });
@@ -196,7 +250,11 @@ describe("relations DSL and namespaces", () => {
     const labels = await db.orchestrate?.write(async (o) => {
       o.put("createOrg", Org, { orgId: "org_3" as never, name: "Gamma" });
       o.put("createUser", User, { userId: "usr_3" as never, email: "u3@example.com" });
-      o.put("join", Membership, { orgId: "org_3" as never, userId: "usr_3" as never, role: "owner" });
+      o.put("join", Membership, {
+        orgId: "org_3" as never,
+        userId: "usr_3" as never,
+        role: "owner",
+      });
     });
     expect(labels?.createOrg?.operation).toBe("Put");
     expect(await db.Org.get({ orgId: "org_3" as never })).toMatchObject({ name: "Gamma" });
@@ -204,12 +262,19 @@ describe("relations DSL and namespaces", () => {
 
   it("supports explicit fan-out orchestration for materialized views", async () => {
     const adapter = createMemoryAdapter();
-    const db = connect(AppTable, { adapter, entities: { Org, User, Membership, Folder, OrgSummary } });
+    const db = connect(AppTable, {
+      adapter,
+      entities: { Org, User, Membership, Folder, OrgSummary },
+    });
     const labels = await db.orchestrate?.fanOut(
       {
         primary: async (o) => {
           o.put("createOrg", Org, { orgId: "org_4" as never, name: "Delta" });
-          o.put("joinOwner", Membership, { orgId: "org_4" as never, userId: "usr_4" as never, role: "owner" });
+          o.put("joinOwner", Membership, {
+            orgId: "org_4" as never,
+            userId: "usr_4" as never,
+            role: "owner",
+          });
         },
         fanOut: async (o) => {
           o.put("summaryUpsert", OrgSummary, { orgId: "org_4" as never, memberCount: "1" });
@@ -219,7 +284,9 @@ describe("relations DSL and namespaces", () => {
     );
     expect(labels?.primary.createOrg?.operation).toBe("Put");
     expect(labels?.fanOut.summaryUpsert?.operation).toBe("Put");
-    expect(await db.OrgSummary.get({ orgId: "org_4" as never })).toMatchObject({ memberCount: "1" });
+    expect(await db.OrgSummary.get({ orgId: "org_4" as never })).toMatchObject({
+      memberCount: "1",
+    });
   });
 
   it("supports declared read bundles with deterministic labels", async () => {
@@ -244,7 +311,11 @@ describe("relations DSL and namespaces", () => {
         ),
     });
     await db.Org.create({ orgId: "org_6" as never, name: "Six" });
-    await db.Membership.create({ orgId: "org_6" as never, userId: "usr_6" as never, role: "member" });
+    await db.Membership.create({
+      orgId: "org_6" as never,
+      userId: "usr_6" as never,
+      role: "member",
+    });
     const out = await db.read?.run("orgProfile", { orgId: "org_6" as never });
     expect(out?.org).toMatchObject({ orgId: "org_6" });
     expect(Array.isArray(out?.members)).toBe(true);
@@ -264,7 +335,9 @@ describe("relations DSL and namespaces", () => {
           { maxDepth: 2 },
         ),
     });
-    await expect(db.read?.run("tooDeep", { orgId: "org_1" as never })).rejects.toThrow(ValidationError);
+    await expect(db.read?.run("tooDeep", { orgId: "org_1" as never })).rejects.toThrow(
+      ValidationError,
+    );
     expect(() =>
       connect(AppTable, {
         adapter,
@@ -291,7 +364,10 @@ describe("relations DSL and namespaces", () => {
             .put("summary", "OrgSummary", (input) => ({ orgId: input.orgId, memberCount: "0" })),
         ),
     });
-    const labels = await db.recipes?.run("createOrgWithSummary", { orgId: "org_7" as never, name: "Seven" });
+    const labels = await db.recipes?.run("createOrgWithSummary", {
+      orgId: "org_7" as never,
+      name: "Seven",
+    });
     expect(labels?.createOrg.operation).toBe("Put");
     expect(await db.Org.get({ orgId: "org_7" as never })).toMatchObject({ name: "Seven" });
     expect(db.recipes?.explain("createOrgWithSummary").steps.length).toBe(2);
@@ -299,7 +375,10 @@ describe("relations DSL and namespaces", () => {
 
   it("supports counterSummary template and summary labels", async () => {
     const adapter = createMemoryAdapter();
-    const db = connect(AppTable, { adapter, entities: { Org, User, Membership, Folder, OrgSummary } });
+    const db = connect(AppTable, {
+      adapter,
+      entities: { Org, User, Membership, Folder, OrgSummary },
+    });
     const labels = await db.orchestrate?.counterSummary({
       primary: async (o) => {
         o.put("org", Org, { orgId: "org_8" as never, name: "Eight" });

--- a/packages/core/test/repository-batch-query-explain-options.test.ts
+++ b/packages/core/test/repository-batch-query-explain-options.test.ts
@@ -163,14 +163,19 @@ describe("repository: batch APIs, query options, return modes, explain", () => {
       ],
     });
     expect((await db.User.get({ userId: "usr_w1" as never }))?.email).toBe("w1@x.com");
-    await db.User.batchWrite({ deletes: [{ userId: "usr_w1" as never }, { userId: "usr_w2" as never }] });
+    await db.User.batchWrite({
+      deletes: [{ userId: "usr_w1" as never }, { userId: "usr_w2" as never }],
+    });
     expect(await db.User.get({ userId: "usr_w1" as never })).toBeNull();
   });
 
   it("create return none and delete return old", async () => {
     const adapter = createMemoryAdapter();
     const db = connect(AppTable, { adapter, entities: { User } });
-    const c = await db.User.create({ userId: "usr_r" as never, email: "r@x.com" }, { return: "none" });
+    const c = await db.User.create(
+      { userId: "usr_r" as never, email: "r@x.com" },
+      { return: "none" },
+    );
     expect(c).toBeUndefined();
     await db.User.create({ userId: "usr_r2" as never, email: "r2@x.com" });
     const old = await db.User.delete({ userId: "usr_r2" as never }, { return: "old" });
@@ -181,7 +186,9 @@ describe("repository: batch APIs, query options, return modes, explain", () => {
     const adapter = createMemoryAdapter();
     const db = connect(AppTable, { adapter, entities: { User } });
     await db.User.create({ userId: "usr_u" as never, email: "u@x.com" });
-    const v = await db.User.update({ userId: "usr_u" as never }).set({ name: "N" }).go({ return: "none" });
+    const v = await db.User.update({ userId: "usr_u" as never })
+      .set({ name: "N" })
+      .go({ return: "none" });
     expect(v).toBeUndefined();
   });
 
@@ -233,13 +240,18 @@ describe("repository: batch APIs, query options, return modes, explain", () => {
     const adapter = createMemoryAdapter();
     const db = connect(LsiTable, { adapter, entities: { LsiUser } });
     await db.LsiUser.create({ userId: "usr_lsi_1" as never, email: "lsi@x.com", status: "active" });
-    const page = await db.LsiUser.find.byStatusLsi({ userId: "usr_lsi_1" as never, status: "active" });
+    const page = await db.LsiUser.find.byStatusLsi({
+      userId: "usr_lsi_1" as never,
+      status: "active",
+    });
     expect(page.items.length).toBeGreaterThanOrEqual(1);
     const scanLsi = await db.LsiUser.find.scanByLsi({});
     expect(scanLsi.items.length).toBeGreaterThanOrEqual(1);
     const scanGsi = await db.LsiUser.find.scanByGsi({});
     expect(scanGsi.items.length).toBeGreaterThanOrEqual(1);
-    await expect(db.LsiUser.find.byEmailGsiBad({ email: "lsi@x.com" })).rejects.toThrow(ValidationError);
+    await expect(db.LsiUser.find.byEmailGsiBad({ email: "lsi@x.com" })).rejects.toThrow(
+      ValidationError,
+    );
     await expect(db.LsiUser.find.scanByGsiBad({})).rejects.toThrow(ValidationError);
   });
 

--- a/packages/core/test/reserved-attrs.test.ts
+++ b/packages/core/test/reserved-attrs.test.ts
@@ -14,7 +14,10 @@ describe("reserved logical attribute names", () => {
         .keys(({ itemId }: { itemId: string }) => ({ pk: key("ITEM", itemId), sk: key("ROOT") }))
         .identity(["itemId"])
         .accessPatterns((ap) => ({
-          byId: ap.get(({ itemId }: { itemId: string }) => ({ pk: key("ITEM", itemId), sk: key("ROOT") })),
+          byId: ap.get(({ itemId }: { itemId: string }) => ({
+            pk: key("ITEM", itemId),
+            sk: key("ROOT"),
+          })),
         })),
     ).toThrow(ValidationError);
   });

--- a/packages/core/test/update-explain.test.ts
+++ b/packages/core/test/update-explain.test.ts
@@ -18,7 +18,9 @@ describe("update explain", () => {
       }));
 
     const db = connect(T, { adapter: createMemoryAdapter(), entities: { E } });
-    const op = db.E.update({ id: "x_1" as never }).set({ name: "n" }).explain();
+    const op = db.E.update({ id: "x_1" as never })
+      .set({ name: "n" })
+      .explain();
     expect(op.operation).toBe("UpdateItem");
     expect(op.updateExpression).toMatch(/^SET /);
     expect(op.key).toEqual({ pk: "P#x_1", sk: "S" });

--- a/packages/core/test/validation.test.ts
+++ b/packages/core/test/validation.test.ts
@@ -9,7 +9,11 @@ describe("validation", () => {
     const schema = { email: string().required() };
     const meta = buildFieldMetaMap(schema, []);
     expect(() =>
-      validateAndApplyDefaults({ email: "a@b.com", extra: 1 } as Record<string, unknown>, schema, meta),
+      validateAndApplyDefaults(
+        { email: "a@b.com", extra: 1 } as Record<string, unknown>,
+        schema,
+        meta,
+      ),
     ).toThrow(ValidationError);
   });
 });

--- a/packages/streams/src/index.ts
+++ b/packages/streams/src/index.ts
@@ -139,10 +139,15 @@ function decodeImage(
 ): { entityName?: string; item?: unknown } {
   if (!image) return {};
   const logical = unmarshall(image as Parameters<typeof unmarshall>[0]) as Record<string, unknown>;
-  const entityName = typeof logical[discriminatorAttr] === "string" ? (logical[discriminatorAttr] as string) : undefined;
+  const entityName =
+    typeof logical[discriminatorAttr] === "string"
+      ? (logical[discriminatorAttr] as string)
+      : undefined;
   if (!entityName) {
     if (mode === "strict") {
-      throw new StreamDecodeError(`streams.decode: Missing discriminator "${discriminatorAttr}" in stream image`);
+      throw new StreamDecodeError(
+        `streams.decode: Missing discriminator "${discriminatorAttr}" in stream image`,
+      );
     }
     return { item: logical };
   }
@@ -164,17 +169,33 @@ export function isTtlRemove(record: Pick<DynamoDBRecord, "eventName" | "userIden
   );
 }
 
-export function decodeStreamRecord(record: DynamoDBRecord, options: DecodeStreamRecordOptions): DecodedStreamEvent {
+export function decodeStreamRecord(
+  record: DynamoDBRecord,
+  options: DecodeStreamRecordOptions,
+): DecodedStreamEvent {
   const mode = options.unknownEntityMode ?? "strict";
   const discriminatorAttr = options.discriminatorAttr ?? "entity";
   assertViewType(record, normalizeRequired(options.requiredViewType));
   const eventName = parseEventName(record.eventName);
 
   const keys = record.dynamodb?.Keys
-    ? (unmarshall(record.dynamodb.Keys as Parameters<typeof unmarshall>[0]) as Record<string, unknown>)
+    ? (unmarshall(record.dynamodb.Keys as Parameters<typeof unmarshall>[0]) as Record<
+        string,
+        unknown
+      >)
     : undefined;
-  const next = decodeImage(record.dynamodb?.NewImage as Record<string, unknown> | undefined, options.decoders, mode, discriminatorAttr);
-  const prev = decodeImage(record.dynamodb?.OldImage as Record<string, unknown> | undefined, options.decoders, mode, discriminatorAttr);
+  const next = decodeImage(
+    record.dynamodb?.NewImage as Record<string, unknown> | undefined,
+    options.decoders,
+    mode,
+    discriminatorAttr,
+  );
+  const prev = decodeImage(
+    record.dynamodb?.OldImage as Record<string, unknown> | undefined,
+    options.decoders,
+    mode,
+    discriminatorAttr,
+  );
   return {
     eventName,
     entityName: next.entityName ?? prev.entityName,
@@ -187,14 +208,19 @@ export function decodeStreamRecord(record: DynamoDBRecord, options: DecodeStream
   };
 }
 
-export function decodeStreamEvent(event: DynamoDBStreamEvent, options: DecodeStreamRecordOptions): readonly DecodedStreamEvent[] {
+export function decodeStreamEvent(
+  event: DynamoDBStreamEvent,
+  options: DecodeStreamRecordOptions,
+): readonly DecodedStreamEvent[] {
   return event.Records.map((record) => decodeStreamRecord(record, options));
 }
 
 export async function handleStreamByEntity(
   event: DynamoDBStreamEvent,
   options: DecodeStreamRecordOptions & {
-    readonly handlers: Partial<Record<EventName, (evt: DecodedStreamEvent) => void | Promise<void>>>;
+    readonly handlers: Partial<
+      Record<EventName, (evt: DecodedStreamEvent) => void | Promise<void>>
+    >;
   },
 ): Promise<void> {
   const decoded = decodeStreamEvent(event, options);

--- a/packages/streams/test/streams.test.ts
+++ b/packages/streams/test/streams.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { DynamoDBRecord, DynamoDBStreamEvent } from "../src/index.js";
-import { decodeStreamEvent, decodeStreamRecord, handleStreamByEntity, isTtlRemove } from "../src/index.js";
+import {
+  decodeStreamEvent,
+  decodeStreamRecord,
+  handleStreamByEntity,
+  isTtlRemove,
+} from "../src/index.js";
 
 function record(base: Partial<DynamoDBRecord>): DynamoDBRecord {
   return {
@@ -81,7 +86,10 @@ describe("@patternmeshjs/streams", () => {
         }),
       ],
     };
-    const [decoded] = decodeStreamEvent(event, { decoders: { User: (i) => i }, requiredViewType: "any" });
+    const [decoded] = decodeStreamEvent(event, {
+      decoders: { User: (i) => i },
+      requiredViewType: "any",
+    });
     expect(decoded.eventName).toBe("REMOVE");
     expect(decoded.oldItem).toMatchObject({ userId: "usr_2" });
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,21 +14,42 @@ importers:
       '@changesets/cli':
         specifier: ^2.31.0
         version: 2.31.0(@types/node@25.6.0)
+      '@commitlint/cli':
+        specifier: ^20.5.0
+        version: 20.5.0(@types/node@25.6.0)(conventional-commits-parser@6.4.0)(typescript@5.9.3)
+      '@commitlint/config-conventional':
+        specifier: ^20.5.0
+        version: 20.5.0
       '@eslint/js':
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.2.1)
+        version: 10.0.1(eslint@10.2.1(jiti@2.6.1))
       eslint:
         specifier: ^10.2.1
-        version: 10.2.1
+        version: 10.2.1(jiti@2.6.1)
+      eslint-config-prettier:
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@10.2.1(jiti@2.6.1))
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
+      lint-staged:
+        specifier: ^16.4.0
+        version: 16.4.0
       marked:
         specifier: ^18.0.2
         version: 18.0.2
+      prettier:
+        specifier: ^3.8.3
+        version: 3.8.3
       publint:
         specifier: ^0.3.18
         version: 0.3.18
       syncpack:
         specifier: ^14.3.0
         version: 14.3.0
+      turbo:
+        specifier: ^2.9.6
+        version: 2.9.6
       typedoc:
         specifier: ^0.28.19
         version: 0.28.19(typescript@5.9.3)
@@ -37,7 +58,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.59.0
-        version: 8.59.0(eslint@10.2.1)(typescript@5.9.3)
+        version: 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
 
   packages/adapter-aws-sdk-v3:
     dependencies:
@@ -56,13 +77,13 @@ importers:
         version: 25.6.0
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@25.6.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)
 
   packages/core:
     devDependencies:
@@ -74,13 +95,13 @@ importers:
         version: 1.3.0
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@25.6.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)
 
   packages/streams:
     dependencies:
@@ -96,13 +117,13 @@ importers:
         version: 25.6.0
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@25.6.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)
 
 packages:
 
@@ -267,6 +288,14 @@ packages:
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
     engines: {node: '>=18.0.0'}
 
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
@@ -332,6 +361,87 @@ packages:
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
+
+  '@commitlint/cli@20.5.0':
+    resolution: {integrity: sha512-yNkyN/tuKTJS3wdVfsZ2tXDM4G4Gi7z+jW54Cki8N8tZqwKBltbIvUUrSbT4hz1bhW/h0CdR+5sCSpXD+wMKaQ==}
+    engines: {node: '>=v18'}
+    hasBin: true
+
+  '@commitlint/config-conventional@20.5.0':
+    resolution: {integrity: sha512-t3Ni88rFw1XMa4nZHgOKJ8fIAT9M2j5TnKyTqJzsxea7FUetlNdYFus9dz+MhIRZmc16P0PPyEfh6X2d/qw8SA==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/config-validator@20.5.0':
+    resolution: {integrity: sha512-T/Uh6iJUzyx7j35GmHWdIiGRQB+ouZDk0pwAaYq4SXgB54KZhFdJ0vYmxiW6AMYICTIWuyMxDBl1jK74oFp/Gw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/ensure@20.5.0':
+    resolution: {integrity: sha512-IpHqAUesBeW1EDDdjzJeaOxU9tnogLAyXLRBn03SHlj1SGENn2JGZqSWGkFvBJkJzfXAuCNtsoYzax+ZPS+puw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/execute-rule@20.0.0':
+    resolution: {integrity: sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/format@20.5.0':
+    resolution: {integrity: sha512-TI9EwFU/qZWSK7a5qyXMpKPPv3qta7FO4tKW+Wt2al7sgMbLWTsAcDpX1cU8k16TRdsiiet9aOw0zpvRXNJu7Q==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/is-ignored@20.5.0':
+    resolution: {integrity: sha512-JWLarAsurHJhPozbuAH6GbP4p/hdOCoqS9zJMfqwswne+/GPs5V0+rrsfOkP68Y8PSLphwtFXV0EzJ+GTXTTGg==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/lint@20.5.0':
+    resolution: {integrity: sha512-jiM3hNUdu04jFBf1VgPdjtIPvbuVfDTBAc6L98AWcoLjF5sYqkulBHBzlVWll4rMF1T5zeQFB6r//a+s+BBKlA==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/load@20.5.0':
+    resolution: {integrity: sha512-sLhhYTL/KxeOTZjjabKDhwidGZan84XKK1+XFkwDYL/4883kIajcz/dZFAhBJmZPtL8+nBx6bnkzA95YxPeDPw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/message@20.4.3':
+    resolution: {integrity: sha512-6akwCYrzcrFcTYz9GyUaWlhisY4lmQ3KvrnabmhoeAV8nRH4dXJAh4+EUQ3uArtxxKQkvxJS78hNX2EU3USgxQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/parse@20.5.0':
+    resolution: {integrity: sha512-SeKWHBMk7YOTnnEWUhx+d1a9vHsjjuo6Uo1xRfPNfeY4bdYFasCH1dDpAv13Lyn+dDPOels+jP6D2GRZqzc5fA==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/read@20.5.0':
+    resolution: {integrity: sha512-JDEIJ2+GnWpK8QqwfmW7O42h0aycJEWNqcdkJnyzLD11nf9dW2dWLTVEa8Wtlo4IZFGLPATjR5neA5QlOvIH1w==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/resolve-extends@20.5.0':
+    resolution: {integrity: sha512-3SHPWUW2v0tyspCTcfSsYml0gses92l6TlogwzvM2cbxDgmhSRc+fldDjvGkCXJrjSM87BBaWYTPWwwyASZRrg==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/rules@20.5.0':
+    resolution: {integrity: sha512-5NdQXQEdnDPT5pK8O39ZA7HohzPRHEsDGU23cyVCNPQy4WegAbAwrQk3nIu7p2sl3dutPk8RZd91yKTrMTnRkQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/to-lines@20.0.0':
+    resolution: {integrity: sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/top-level@20.4.3':
+    resolution: {integrity: sha512-qD9xfP6dFg5jQ3NMrOhG0/w5y3bBUsVGyJvXxdWEwBm8hyx4WOk3kKXw28T5czBYvyeCVJgJJ6aoJZUWDpaacQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/types@20.5.0':
+    resolution: {integrity: sha512-ZJoS8oSq2CAZEpc/YI9SulLrdiIyXeHb/OGqGrkUP6Q7YV+0ouNAa7GjqRdXeQPncHQIDz/jbCTlHScvYvO/gA==}
+    engines: {node: '>=v18'}
+
+  '@conventional-changelog/git-client@2.7.0':
+    resolution: {integrity: sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      conventional-commits-filter: ^5.0.0
+      conventional-commits-parser: ^6.4.0
+    peerDependenciesMeta:
+      conventional-commits-filter:
+        optional: true
+      conventional-commits-parser:
+        optional: true
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -738,6 +848,14 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@simple-libs/child-process-utils@1.0.2':
+    resolution: {integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==}
+    engines: {node: '>=18'}
+
+  '@simple-libs/stream-utils@1.2.0':
+    resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
+    engines: {node: '>=18'}
+
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
@@ -914,6 +1032,36 @@ packages:
     resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
     engines: {node: '>=18.0.0'}
 
+  '@turbo/darwin-64@2.9.6':
+    resolution: {integrity: sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.9.6':
+    resolution: {integrity: sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.9.6':
+    resolution: {integrity: sha512-YKi05jnNHaD7vevgYwahpzGwbsNNTwzU2c7VZdmdFm7+cGDP4oREUWSsainiMfRqjRuolQxBwRn8wf1jmu+YZA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@turbo/linux-arm64@2.9.6':
+    resolution: {integrity: sha512-02o/ZS69cOYEDczXvOB2xmyrtzjQ2hVFtWZK1iqxXUfzMmTjZK4UumrfNnjckSg+gqeBfnPRHa0NstA173Ik3g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/windows-64@2.9.6':
+    resolution: {integrity: sha512-wVdQjvnBI15wB6JrA+43CtUtagjIMmX6XYO758oZHAsCNSxqRlJtdyujih0D8OCnwCRWiGWGI63zAxR0hO6s9g==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.9.6':
+    resolution: {integrity: sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A==}
+    cpu: [arm64]
+    os: [win32]
+
   '@types/aws-lambda@8.10.161':
     resolution: {integrity: sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==}
 
@@ -1045,6 +1193,9 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -1065,6 +1216,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -1073,6 +1228,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  array-ify@1.0.0:
+    resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -1111,6 +1269,10 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
@@ -1141,6 +1303,10 @@ packages:
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
   cli-highlight@2.1.11:
     resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
     engines: {node: '>=8.0.0', npm: '>=5.0.0'}
@@ -1150,8 +1316,16 @@ packages:
     resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
     engines: {node: 10.* || >= 12.*}
 
+  cli-truncate@5.2.0:
+    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
+    engines: {node: '>=20'}
+
   cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1160,13 +1334,23 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
 
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
+
+  compare-func@2.0.0:
+    resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -1174,6 +1358,36 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
+
+  conventional-changelog-angular@8.3.1:
+    resolution: {integrity: sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==}
+    engines: {node: '>=18'}
+
+  conventional-changelog-conventionalcommits@9.3.1:
+    resolution: {integrity: sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==}
+    engines: {node: '>=18'}
+
+  conventional-commits-parser@6.4.0:
+    resolution: {integrity: sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  cosmiconfig-typescript-loader@6.3.0:
+    resolution: {integrity: sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==}
+    engines: {node: '>=v18'}
+    peerDependencies:
+      '@types/node': '*'
+      cosmiconfig: '>=9'
+      typescript: '>=5'
+
+  cosmiconfig@9.0.1:
+    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1203,6 +1417,13 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  dot-prop@5.3.0:
+    resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
+    engines: {node: '>=8'}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -1217,9 +1438,16 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -1236,6 +1464,12 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  eslint-config-prettier@10.1.8:
+    resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
 
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
@@ -1287,6 +1521,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -1306,6 +1543,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fast-xml-builder@1.1.5:
     resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
@@ -1372,6 +1612,15 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
+
+  git-raw-commits@5.0.1:
+    resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1379,6 +1628,10 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  global-directory@4.0.1:
+    resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
+    engines: {node: '>=18'}
 
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
@@ -1398,6 +1651,11 @@ packages:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
 
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -1410,9 +1668,23 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  ini@4.1.1:
+    resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1422,6 +1694,10 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -1429,6 +1705,14 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-obj@2.0.0:
+    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
+    engines: {node: '>=8'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
@@ -1441,9 +1725,16 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
@@ -1459,8 +1750,14 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1485,6 +1782,15 @@ packages:
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
+  lint-staged@16.4.0:
+    resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
+    engines: {node: '>=20.17'}
+    hasBin: true
+
+  listr2@9.0.5:
+    resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
+    engines: {node: '>=20.0.0'}
+
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1497,8 +1803,27 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.kebabcase@4.1.1:
+    resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
+
+  lodash.mergewith@4.6.2:
+    resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
+
+  lodash.snakecase@4.1.1:
+    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
+
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+
+  lodash.upperfirst@4.3.1:
+    resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
+
+  log-update@6.1.0:
+    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
+    engines: {node: '>=18'}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -1536,6 +1861,10 @@ packages:
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
+  meow@13.2.0:
+    resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
+    engines: {node: '>=18'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1544,9 +1873,16 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
@@ -1582,6 +1918,10 @@ packages:
 
   obliterator@1.6.1:
     resolution: {integrity: sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1623,6 +1963,14 @@ packages:
 
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
 
   parse5-htmlparser2-tree-adapter@6.0.1:
     resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
@@ -1709,6 +2057,11 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   publint@0.3.18:
     resolution: {integrity: sha512-JRJFeBTrfx4qLwEuGFPk+haJOJN97KnPuK01yj+4k/Wj5BgoOK5uNsivporiqBjk2JDaslg7qJOhGRnpltGeog==}
     engines: {node: '>=18'}
@@ -1740,13 +2093,28 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
@@ -1791,6 +2159,14 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
+    engines: {node: '>=18'}
+
+  slice-ansi@8.0.0:
+    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
+    engines: {node: '>=20'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1811,13 +2187,29 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.0:
+    resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
+    engines: {node: '>=20'}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -1904,6 +2296,10 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
@@ -1958,6 +2354,10 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  turbo@2.9.6:
+    resolution: {integrity: sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2102,6 +2502,10 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -2115,9 +2519,17 @@ packages:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
 
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
   yargs@16.2.0:
     resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
     engines: {node: '>=10'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -2546,6 +2958,14 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.2.4': {}
 
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
   '@babel/runtime@7.29.2': {}
 
   '@braidai/lang@1.1.2': {}
@@ -2696,6 +3116,128 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
+  '@commitlint/cli@20.5.0(@types/node@25.6.0)(conventional-commits-parser@6.4.0)(typescript@5.9.3)':
+    dependencies:
+      '@commitlint/format': 20.5.0
+      '@commitlint/lint': 20.5.0
+      '@commitlint/load': 20.5.0(@types/node@25.6.0)(typescript@5.9.3)
+      '@commitlint/read': 20.5.0(conventional-commits-parser@6.4.0)
+      '@commitlint/types': 20.5.0
+      tinyexec: 1.1.1
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - conventional-commits-filter
+      - conventional-commits-parser
+      - typescript
+
+  '@commitlint/config-conventional@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      conventional-changelog-conventionalcommits: 9.3.1
+
+  '@commitlint/config-validator@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      ajv: 8.18.0
+
+  '@commitlint/ensure@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      lodash.camelcase: 4.3.0
+      lodash.kebabcase: 4.1.1
+      lodash.snakecase: 4.1.1
+      lodash.startcase: 4.4.0
+      lodash.upperfirst: 4.3.1
+
+  '@commitlint/execute-rule@20.0.0': {}
+
+  '@commitlint/format@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      picocolors: 1.1.1
+
+  '@commitlint/is-ignored@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      semver: 7.7.4
+
+  '@commitlint/lint@20.5.0':
+    dependencies:
+      '@commitlint/is-ignored': 20.5.0
+      '@commitlint/parse': 20.5.0
+      '@commitlint/rules': 20.5.0
+      '@commitlint/types': 20.5.0
+
+  '@commitlint/load@20.5.0(@types/node@25.6.0)(typescript@5.9.3)':
+    dependencies:
+      '@commitlint/config-validator': 20.5.0
+      '@commitlint/execute-rule': 20.0.0
+      '@commitlint/resolve-extends': 20.5.0
+      '@commitlint/types': 20.5.0
+      cosmiconfig: 9.0.1(typescript@5.9.3)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@25.6.0)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
+      is-plain-obj: 4.1.0
+      lodash.mergewith: 4.6.2
+      picocolors: 1.1.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - typescript
+
+  '@commitlint/message@20.4.3': {}
+
+  '@commitlint/parse@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      conventional-changelog-angular: 8.3.1
+      conventional-commits-parser: 6.4.0
+
+  '@commitlint/read@20.5.0(conventional-commits-parser@6.4.0)':
+    dependencies:
+      '@commitlint/top-level': 20.4.3
+      '@commitlint/types': 20.5.0
+      git-raw-commits: 5.0.1(conventional-commits-parser@6.4.0)
+      minimist: 1.2.8
+      tinyexec: 1.1.1
+    transitivePeerDependencies:
+      - conventional-commits-filter
+      - conventional-commits-parser
+
+  '@commitlint/resolve-extends@20.5.0':
+    dependencies:
+      '@commitlint/config-validator': 20.5.0
+      '@commitlint/types': 20.5.0
+      global-directory: 4.0.1
+      import-meta-resolve: 4.2.0
+      lodash.mergewith: 4.6.2
+      resolve-from: 5.0.0
+
+  '@commitlint/rules@20.5.0':
+    dependencies:
+      '@commitlint/ensure': 20.5.0
+      '@commitlint/message': 20.4.3
+      '@commitlint/to-lines': 20.0.0
+      '@commitlint/types': 20.5.0
+
+  '@commitlint/to-lines@20.0.0': {}
+
+  '@commitlint/top-level@20.4.3':
+    dependencies:
+      escalade: 3.2.0
+
+  '@commitlint/types@20.5.0':
+    dependencies:
+      conventional-commits-parser: 6.4.0
+      picocolors: 1.1.1
+
+  '@conventional-changelog/git-client@2.7.0(conventional-commits-parser@6.4.0)':
+    dependencies:
+      '@simple-libs/child-process-utils': 1.0.2
+      '@simple-libs/stream-utils': 1.2.0
+      semver: 7.7.4
+    optionalDependencies:
+      conventional-commits-parser: 6.4.0
+
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
@@ -2774,9 +3316,9 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.2.1)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.2.1(jiti@2.6.1))':
     dependencies:
-      eslint: 10.2.1
+      eslint: 10.2.1(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -2797,9 +3339,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.2.1)':
+  '@eslint/js@10.0.1(eslint@10.2.1(jiti@2.6.1))':
     optionalDependencies:
-      eslint: 10.2.1
+      eslint: 10.2.1(jiti@2.6.1)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -2981,6 +3523,12 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@simple-libs/child-process-utils@1.0.2':
+    dependencies:
+      '@simple-libs/stream-utils': 1.2.0
+
+  '@simple-libs/stream-utils@1.2.0': {}
 
   '@sindresorhus/is@4.6.0': {}
 
@@ -3259,6 +3807,24 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@turbo/darwin-64@2.9.6':
+    optional: true
+
+  '@turbo/darwin-arm64@2.9.6':
+    optional: true
+
+  '@turbo/linux-64@2.9.6':
+    optional: true
+
+  '@turbo/linux-arm64@2.9.6':
+    optional: true
+
+  '@turbo/windows-64@2.9.6':
+    optional: true
+
+  '@turbo/windows-arm64@2.9.6':
+    optional: true
+
   '@types/aws-lambda@8.10.161': {}
 
   '@types/chai@5.2.3':
@@ -3286,15 +3852,15 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@10.2.1)(typescript@5.9.3))(eslint@10.2.1)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.0(eslint@10.2.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.59.0
-      '@typescript-eslint/type-utils': 8.59.0(eslint@10.2.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.59.0
-      eslint: 10.2.1
+      eslint: 10.2.1(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -3302,14 +3868,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.0(eslint@10.2.1)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.0
       '@typescript-eslint/types': 8.59.0
       '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.59.0
       debug: 4.4.3
-      eslint: 10.2.1
+      eslint: 10.2.1(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -3332,13 +3898,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.59.0(eslint@10.2.1)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.59.0
       '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 10.2.1
+      eslint: 10.2.1(jiti@2.6.1)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -3361,13 +3927,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.59.0(eslint@10.2.1)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.59.0
       '@typescript-eslint/types': 8.59.0
       '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
-      eslint: 10.2.1
+      eslint: 10.2.1(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -3385,13 +3951,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@25.6.0)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@25.6.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -3432,6 +3998,13 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-colors@4.1.3: {}
 
   ansi-escapes@7.3.0:
@@ -3446,6 +4019,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@6.2.3: {}
+
   any-promise@1.3.0: {}
 
   argparse@1.0.10:
@@ -3453,6 +4028,8 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  array-ify@1.0.0: {}
 
   array-union@2.1.0: {}
 
@@ -3481,6 +4058,8 @@ snapshots:
 
   cac@6.7.14: {}
 
+  callsites@3.1.0: {}
+
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
@@ -3508,6 +4087,10 @@ snapshots:
 
   cjs-module-lexer@1.4.3: {}
 
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
   cli-highlight@2.1.11:
     dependencies:
       chalk: 4.1.2
@@ -3523,7 +4106,18 @@ snapshots:
     optionalDependencies:
       '@colors/colors': 1.5.0
 
+  cli-truncate@5.2.0:
+    dependencies:
+      slice-ansi: 8.0.0
+      string-width: 8.2.0
+
   cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
       strip-ansi: 6.0.1
@@ -3535,13 +4129,51 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  colorette@2.0.20: {}
+
   commander@10.0.1: {}
 
+  commander@14.0.3: {}
+
   commander@4.1.1: {}
+
+  compare-func@2.0.0:
+    dependencies:
+      array-ify: 1.0.0
+      dot-prop: 5.3.0
 
   confbox@0.1.8: {}
 
   consola@3.4.2: {}
+
+  conventional-changelog-angular@8.3.1:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-changelog-conventionalcommits@9.3.1:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-commits-parser@6.4.0:
+    dependencies:
+      '@simple-libs/stream-utils': 1.2.0
+      meow: 13.2.0
+
+  cosmiconfig-typescript-loader@6.3.0(@types/node@25.6.0)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
+    dependencies:
+      '@types/node': 25.6.0
+      cosmiconfig: 9.0.1(typescript@5.9.3)
+      jiti: 2.6.1
+      typescript: 5.9.3
+
+  cosmiconfig@9.0.1(typescript@5.9.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.9.3
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3563,6 +4195,12 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
+  dot-prop@5.3.0:
+    dependencies:
+      is-obj: 2.0.0
+
+  emoji-regex@10.6.0: {}
+
   emoji-regex@8.0.0: {}
 
   emojilib@2.4.0: {}
@@ -3574,7 +4212,13 @@ snapshots:
 
   entities@4.5.0: {}
 
+  env-paths@2.2.1: {}
+
   environment@1.1.0: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
 
   es-module-lexer@1.7.0: {}
 
@@ -3611,6 +4255,10 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  eslint-config-prettier@10.1.8(eslint@10.2.1(jiti@2.6.1)):
+    dependencies:
+      eslint: 10.2.1(jiti@2.6.1)
+
   eslint-scope@9.1.2:
     dependencies:
       '@types/esrecurse': 4.3.1
@@ -3622,9 +4270,9 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.2.1:
+  eslint@10.2.1(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.5
       '@eslint/config-helpers': 0.5.5
@@ -3654,6 +4302,8 @@ snapshots:
       minimatch: 10.2.5
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -3681,6 +4331,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@5.0.4: {}
+
   expect-type@1.3.0: {}
 
   extendable-error@0.1.7: {}
@@ -3698,6 +4350,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-uri@3.1.0: {}
 
   fast-xml-builder@1.1.5:
     dependencies:
@@ -3767,6 +4421,16 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-east-asian-width@1.5.0: {}
+
+  git-raw-commits@5.0.1(conventional-commits-parser@6.4.0):
+    dependencies:
+      '@conventional-changelog/git-client': 2.7.0(conventional-commits-parser@6.4.0)
+      meow: 13.2.0
+    transitivePeerDependencies:
+      - conventional-commits-filter
+      - conventional-commits-parser
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -3774,6 +4438,10 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  global-directory@4.0.1:
+    dependencies:
+      ini: 4.1.1
 
   globby@11.1.0:
     dependencies:
@@ -3792,6 +4460,8 @@ snapshots:
 
   human-id@4.1.3: {}
 
+  husky@9.1.7: {}
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -3800,17 +4470,36 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  import-meta-resolve@4.2.0: {}
+
   imurmurhash@0.1.4: {}
+
+  ini@4.1.1: {}
+
+  is-arrayish@0.2.1: {}
 
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
 
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
 
   is-number@7.0.0: {}
+
+  is-obj@2.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-subdir@1.2.0:
     dependencies:
@@ -3820,7 +4509,11 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  jiti@2.6.1: {}
+
   joycon@3.1.1: {}
+
+  js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
 
@@ -3835,7 +4528,11 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-parse-even-better-errors@2.3.1: {}
+
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -3860,6 +4557,24 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
+  lint-staged@16.4.0:
+    dependencies:
+      commander: 14.0.3
+      listr2: 9.0.5
+      picomatch: 4.0.4
+      string-argv: 0.3.2
+      tinyexec: 1.1.1
+      yaml: 2.8.3
+
+  listr2@9.0.5:
+    dependencies:
+      cli-truncate: 5.2.0
+      colorette: 2.0.20
+      eventemitter3: 5.0.4
+      log-update: 6.1.0
+      rfdc: 1.4.1
+      wrap-ansi: 9.0.2
+
   load-tsconfig@0.2.5: {}
 
   locate-path@5.0.0:
@@ -3870,7 +4585,25 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.camelcase@4.3.0: {}
+
+  lodash.kebabcase@4.1.1: {}
+
+  lodash.mergewith@4.6.2: {}
+
+  lodash.snakecase@4.1.1: {}
+
   lodash.startcase@4.4.0: {}
+
+  lodash.upperfirst@4.3.1: {}
+
+  log-update@6.1.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      cli-cursor: 5.0.0
+      slice-ansi: 7.1.2
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
 
   loupe@3.2.1: {}
 
@@ -3908,6 +4641,8 @@ snapshots:
 
   mdurl@2.0.0: {}
 
+  meow@13.2.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
@@ -3915,9 +4650,13 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  mimic-function@5.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
+
+  minimist@1.2.8: {}
 
   mlly@1.8.2:
     dependencies:
@@ -3954,6 +4693,10 @@ snapshots:
   object-assign@4.1.1: {}
 
   obliterator@1.6.1: {}
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
 
   optionator@0.9.4:
     dependencies:
@@ -3996,6 +4739,17 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
   parse5-htmlparser2-tree-adapter@6.0.1:
     dependencies:
       parse5: 6.0.1
@@ -4032,10 +4786,11 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.10)(yaml@2.8.3):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.10)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
+      jiti: 2.6.1
       postcss: 8.5.10
       yaml: 2.8.3
 
@@ -4048,6 +4803,8 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   prettier@2.8.8: {}
+
+  prettier@3.8.3: {}
 
   publint@0.3.18:
     dependencies:
@@ -4075,9 +4832,20 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
+  resolve-from@4.0.0: {}
+
   resolve-from@5.0.0: {}
 
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
   reusify@1.1.0: {}
+
+  rfdc@1.4.1: {}
 
   rollup@4.60.2:
     dependencies:
@@ -4138,6 +4906,16 @@ snapshots:
 
   slash@3.0.0: {}
 
+  slice-ansi@7.1.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
+  slice-ansi@8.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
@@ -4153,15 +4931,32 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  string-argv@0.3.2: {}
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
 
@@ -4239,6 +5034,8 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
+  tinyexec@1.1.1: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -4264,7 +5061,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(postcss@8.5.10)(typescript@5.9.3)(yaml@2.8.3):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.10)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -4275,7 +5072,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.10)(yaml@2.8.3)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.10)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.60.2
       source-map: 0.7.6
@@ -4292,6 +5089,15 @@ snapshots:
       - tsx
       - yaml
 
+  turbo@2.9.6:
+    optionalDependencies:
+      '@turbo/darwin-64': 2.9.6
+      '@turbo/darwin-arm64': 2.9.6
+      '@turbo/linux-64': 2.9.6
+      '@turbo/linux-arm64': 2.9.6
+      '@turbo/windows-64': 2.9.6
+      '@turbo/windows-arm64': 2.9.6
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -4305,13 +5111,13 @@ snapshots:
       typescript: 5.9.3
       yaml: 2.8.3
 
-  typescript-eslint@8.59.0(eslint@10.2.1)(typescript@5.9.3):
+  typescript-eslint@8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.0(@typescript-eslint/parser@8.59.0(eslint@10.2.1)(typescript@5.9.3))(eslint@10.2.1)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.59.0(eslint@10.2.1)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.59.0(@typescript-eslint/parser@8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1)(typescript@5.9.3)
-      eslint: 10.2.1
+      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 10.2.1(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -4336,13 +5142,13 @@ snapshots:
 
   validate-npm-package-name@5.0.1: {}
 
-  vite-node@3.2.4(@types/node@25.6.0)(yaml@2.8.3):
+  vite-node@3.2.4(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.2(@types/node@25.6.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4357,7 +5163,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.2(@types/node@25.6.0)(yaml@2.8.3):
+  vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -4368,13 +5174,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
       fsevents: 2.3.3
+      jiti: 2.6.1
       yaml: 2.8.3
 
-  vitest@3.2.4(@types/node@25.6.0)(yaml@2.8.3):
+  vitest@3.2.4(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@25.6.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -4392,8 +5199,8 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.2(@types/node@25.6.0)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@25.6.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0
@@ -4428,11 +5235,19 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
   y18n@5.0.8: {}
 
   yaml@2.8.3: {}
 
   yargs-parser@20.2.9: {}
+
+  yargs-parser@21.1.1: {}
 
   yargs@16.2.0:
     dependencies:
@@ -4443,5 +5258,15 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 20.2.9
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -22,17 +22,53 @@ const pages = [
   { src: "SECURITY.md", dest: "SECURITY.html", title: "Security" },
   { src: "CODE_OF_CONDUCT.md", dest: "CODE_OF_CONDUCT.html", title: "Code of Conduct" },
   { src: "RELEASE_CHECKLIST.md", dest: "RELEASE_CHECKLIST.html", title: "Release checklist" },
-  { src: "docs/single-table-patterns.md", dest: "docs/single-table-patterns.html", title: "Single-table design" },
+  {
+    src: "docs/single-table-patterns.md",
+    dest: "docs/single-table-patterns.html",
+    title: "Single-table design",
+  },
   { src: "docs/table-setup.md", dest: "docs/table-setup.html", title: "Table setup" },
   { src: "docs/API_REFERENCE.md", dest: "docs/API_REFERENCE.html", title: "API reference" },
-  { src: "docs/guides/relations.md", dest: "docs/guides/relations.html", title: "Relations cookbook" },
-  { src: "docs/guides/bundles-and-recipes.md", dest: "docs/guides/bundles-and-recipes.html", title: "Bundles and recipes" },
-  { src: "docs/guides/lifecycle.md", dest: "docs/guides/lifecycle.html", title: "Lifecycle recipes" },
-  { src: "docs/guides/complex-attributes.md", dest: "docs/guides/complex-attributes.html", title: "Complex attributes" },
-  { src: "docs/guides/streams-advanced.md", dest: "docs/guides/streams-advanced.html", title: "Streams advanced" },
-  { src: "packages/core/README.md", dest: "packages/core/index.html", title: "@patternmeshjs/core" },
-  { src: "packages/adapter-aws-sdk-v3/README.md", dest: "packages/adapter-aws-sdk-v3/index.html", title: "@patternmeshjs/aws-sdk-v3" },
-  { src: "packages/streams/README.md", dest: "packages/streams/index.html", title: "@patternmeshjs/streams" },
+  {
+    src: "docs/guides/relations.md",
+    dest: "docs/guides/relations.html",
+    title: "Relations cookbook",
+  },
+  {
+    src: "docs/guides/bundles-and-recipes.md",
+    dest: "docs/guides/bundles-and-recipes.html",
+    title: "Bundles and recipes",
+  },
+  {
+    src: "docs/guides/lifecycle.md",
+    dest: "docs/guides/lifecycle.html",
+    title: "Lifecycle recipes",
+  },
+  {
+    src: "docs/guides/complex-attributes.md",
+    dest: "docs/guides/complex-attributes.html",
+    title: "Complex attributes",
+  },
+  {
+    src: "docs/guides/streams-advanced.md",
+    dest: "docs/guides/streams-advanced.html",
+    title: "Streams advanced",
+  },
+  {
+    src: "packages/core/README.md",
+    dest: "packages/core/index.html",
+    title: "@patternmeshjs/core",
+  },
+  {
+    src: "packages/adapter-aws-sdk-v3/README.md",
+    dest: "packages/adapter-aws-sdk-v3/index.html",
+    title: "@patternmeshjs/aws-sdk-v3",
+  },
+  {
+    src: "packages/streams/README.md",
+    dest: "packages/streams/index.html",
+    title: "@patternmeshjs/streams",
+  },
 ];
 
 function rewriteHref(href) {

--- a/scripts/site-template.html
+++ b/scripts/site-template.html
@@ -34,8 +34,8 @@
         color: var(--fg);
         background: var(--bg);
         font-family:
-          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
-          Cantarell, "Helvetica Neue", Arial, sans-serif;
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+          "Helvetica Neue", Arial, sans-serif;
         line-height: 1.6;
       }
       a {

--- a/syncpack.config.js
+++ b/syncpack.config.js
@@ -4,7 +4,7 @@ export default {
     {
       label: "aws-sdk-v3",
       dependencies: ["@aws-sdk/*"],
-      packages: ["packages/*"]
-    }
-  ]
+      packages: ["packages/*"],
+    },
+  ],
 };

--- a/tests-smoke/smoke.mjs
+++ b/tests-smoke/smoke.mjs
@@ -54,14 +54,7 @@ writeFileSync(
 
 run(
   "pnpm",
-  [
-    "add",
-    coreTgz,
-    adapterTgz,
-    streamsTgz,
-    "@aws-sdk/client-dynamodb",
-    "@aws-sdk/lib-dynamodb",
-  ],
+  ["add", coreTgz, adapterTgz, streamsTgz, "@aws-sdk/client-dynamodb", "@aws-sdk/lib-dynamodb"],
   appDir,
 );
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "ui": "stream",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "inputs": ["src/**", "tsup.config.ts", "tsconfig.json", "package.json"],
+      "outputs": ["dist/**"]
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "inputs": ["src/**", "test/**", "vitest.config.ts", "package.json"],
+      "outputs": [],
+      "env": ["DYNAMODB_ENDPOINT"]
+    },
+    "typecheck": {
+      "dependsOn": ["^build"],
+      "inputs": ["src/**", "test/**", "tsconfig.json", "package.json"],
+      "outputs": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- adopt Prettier with root `format` / `format:check`, run a one-shot repository formatting sweep, and record the sweep commit in `.git-blame-ignore-revs`
- introduce Turbo task orchestration (`build`, `test`, `typecheck`) and cache `.turbo` in CI/release workflows
- add Husky + lint-staged pre-commit formatting/linting, commitlint commit-msg checks, and contributor guidance updates
- harden CI with PR concurrency cancellation, Node 18/20/22 matrix coverage, `syncpack lint`, format checks, dependency review, and step timeouts

## Test plan
- [x] `pnpm install`
- [x] `pnpm build`
- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm publint`
- [x] `pnpm attw`