### PR TITLE
test(coverage): add behavior-driven branch hardening suites

### DIFF
--- a/packages/adapter-aws-sdk-v3/test/index.unit.test.ts
+++ b/packages/adapter-aws-sdk-v3/test/index.unit.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
-import { BatchWriteCommand, TransactWriteCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  BatchGetCommand,
+  BatchWriteCommand,
+  DeleteCommand,
+  PutCommand,
+  QueryCommand,
+  ScanCommand,
+  TransactGetCommand,
+  TransactWriteCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
 import { createAwsSdkV3Adapter } from "../src/index.js";
 
 describe("aws-sdk-v3 adapter transact write serialization", () => {
@@ -129,5 +139,90 @@ describe("aws-sdk-v3 adapter transact write serialization", () => {
     );
     expect(out.unprocessedPuts).toEqual([{ tableName: "app", item: { pk: "P", sk: "S" } }]);
     expect(out.unprocessedDeletes).toEqual([{ tableName: "app", key: { pk: "D", sk: "K" } }]);
+  });
+
+  it("normalizes query and scan missing Items to empty arrays", async () => {
+    const send = vi.fn().mockResolvedValueOnce({}).mockResolvedValueOnce({});
+    const docClient = { send } as unknown as import("@aws-sdk/lib-dynamodb").DynamoDBDocumentClient;
+    const adapter = createAwsSdkV3Adapter(docClient);
+
+    const q = await adapter.query({
+      tableName: "app",
+      keyConditionExpression: "#pk = :pk",
+      expressionAttributeNames: { "#pk": "pk" },
+      expressionAttributeValues: { ":pk": "A" },
+    });
+    const s = await adapter.scan({ tableName: "app" });
+
+    expect(send.mock.calls[0]?.[0]).toBeInstanceOf(QueryCommand);
+    expect(send.mock.calls[1]?.[0]).toBeInstanceOf(ScanCommand);
+    expect(q.items).toEqual([]);
+    expect(s.items).toEqual([]);
+  });
+
+  it("returns null when update has no Attributes", async () => {
+    const send = vi.fn(async () => ({}));
+    const docClient = { send } as unknown as import("@aws-sdk/lib-dynamodb").DynamoDBDocumentClient;
+    const adapter = createAwsSdkV3Adapter(docClient);
+
+    const out = await adapter.updateItem({
+      tableName: "app",
+      key: { pk: "A", sk: "B" },
+      updateExpression: "SET #n = :n",
+      expressionAttributeNames: { "#n": "name" },
+      expressionAttributeValues: { ":n": "Ada" },
+    });
+
+    expect(send.mock.calls[0]?.[0]).toBeInstanceOf(UpdateCommand);
+    expect(out).toBeNull();
+  });
+
+  it("normalizes batchGet missing Responses and UnprocessedKeys", async () => {
+    const send = vi.fn(async () => ({}));
+    const docClient = { send } as unknown as import("@aws-sdk/lib-dynamodb").DynamoDBDocumentClient;
+    const adapter = createAwsSdkV3Adapter(docClient);
+
+    const out = await adapter.batchGetItem({
+      tableName: "app",
+      keys: [{ pk: "A", sk: "B" }],
+    });
+
+    expect(send.mock.calls[0]?.[0]).toBeInstanceOf(BatchGetCommand);
+    expect(out.items).toEqual([]);
+    expect(out.unprocessedKeys).toBeUndefined();
+  });
+
+  it("maps transactGet responses positionally with hit/miss", async () => {
+    const send = vi.fn(async () => ({
+      Responses: [{ Item: { pk: "A", sk: "1" } }, {}],
+    }));
+    const docClient = { send } as unknown as import("@aws-sdk/lib-dynamodb").DynamoDBDocumentClient;
+    const adapter = createAwsSdkV3Adapter(docClient);
+
+    const out = await adapter.transactGetItems({
+      items: [
+        { tableName: "app", key: { pk: "A", sk: "1" } },
+        { tableName: "app", key: { pk: "A", sk: "2" } },
+      ],
+    });
+
+    expect(send.mock.calls[0]?.[0]).toBeInstanceOf(TransactGetCommand);
+    expect(out.responses).toEqual([{ pk: "A", sk: "1" }, null]);
+  });
+
+  it("omits ReturnValues when not provided for put/delete", async () => {
+    const send = vi.fn(async () => ({}));
+    const docClient = { send } as unknown as import("@aws-sdk/lib-dynamodb").DynamoDBDocumentClient;
+    const adapter = createAwsSdkV3Adapter(docClient);
+
+    await adapter.putItem({ tableName: "app", item: { pk: "A", sk: "B" } });
+    await adapter.deleteItem({ tableName: "app", key: { pk: "A", sk: "B" } });
+
+    const putCmd = send.mock.calls[0]?.[0] as PutCommand;
+    const delCmd = send.mock.calls[1]?.[0] as DeleteCommand;
+    expect(putCmd).toBeInstanceOf(PutCommand);
+    expect(delCmd).toBeInstanceOf(DeleteCommand);
+    expect(putCmd.input.ReturnValues).toBeUndefined();
+    expect(delCmd.input.ReturnValues).toBeUndefined();
   });
 });

--- a/packages/core/test/aws-error-classifiers.test.ts
+++ b/packages/core/test/aws-error-classifiers.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  isConditionalCheckFailed,
+  isIdempotentParameterMismatch,
+  isTransactionCanceled,
+  readTransactionCancellationReasons,
+} from "../src/aws-error.js";
+
+describe("aws error classifiers", () => {
+  it("matches by name and __type", () => {
+    expect(isConditionalCheckFailed({ name: "ConditionalCheckFailedException" })).toBe(true);
+    expect(isConditionalCheckFailed({ __type: "ConditionalCheckFailedException" })).toBe(true);
+    expect(isTransactionCanceled({ name: "TransactionCanceledException" })).toBe(true);
+    expect(isTransactionCanceled({ __type: "TransactionCanceledException" })).toBe(true);
+    expect(isIdempotentParameterMismatch({ name: "IdempotentParameterMismatchException" })).toBe(
+      true,
+    );
+    expect(isIdempotentParameterMismatch({ __type: "IdempotentParameterMismatchException" })).toBe(
+      true,
+    );
+  });
+
+  it("returns false for malformed classifier input", () => {
+    expect(isConditionalCheckFailed(null)).toBe(false);
+    expect(isConditionalCheckFailed("oops")).toBe(false);
+    expect(isTransactionCanceled(42)).toBe(false);
+    expect(isIdempotentParameterMismatch(undefined)).toBe(false);
+  });
+
+  it("extracts cancellation reasons from common shapes", () => {
+    const reasons = [{ Code: "ConditionalCheckFailed", Message: "failed" }];
+    expect(readTransactionCancellationReasons({ CancellationReasons: reasons })).toEqual(reasons);
+    expect(readTransactionCancellationReasons({ cancellationReasons: reasons })).toEqual(reasons);
+  });
+
+  it("falls back to empty reasons for malformed inputs", () => {
+    expect(readTransactionCancellationReasons({})).toEqual([]);
+    expect(readTransactionCancellationReasons({ CancellationReasons: {} })).toEqual([]);
+    expect(readTransactionCancellationReasons("bad")).toEqual([]);
+  });
+});

--- a/packages/core/test/connect-transact-update-guards.test.ts
+++ b/packages/core/test/connect-transact-update-guards.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  ConfigurationError,
+  ValidationError,
+  connect,
+  defineTable,
+  entity,
+  id,
+  key,
+  string,
+} from "../src/index.js";
+import { createMemoryAdapter } from "./mock-adapter.js";
+
+const Table = defineTable({ name: "guard_table", partitionKey: "pk", sortKey: "sk" });
+const OtherTable = defineTable({ name: "guard_other", partitionKey: "pk", sortKey: "sk" });
+
+const User = entity("User", {
+  userId: id("usr").required(),
+  email: string().required(),
+  status: string().optional(),
+})
+  .inTable(Table)
+  .keys(({ userId }) => ({ pk: key("USER", userId), sk: key("PROFILE") }))
+  .identity(["userId"])
+  .accessPatterns((ap) => ({
+    byId: ap.get(({ userId }) => ({ pk: key("USER", userId), sk: key("PROFILE") })),
+    scanAll: ap.scan(undefined, () => ({ limit: 10 })),
+  }));
+
+const UserOtherTable = entity("UserOther", {
+  userId: id("usr").required(),
+  email: string().required(),
+})
+  .inTable(OtherTable)
+  .keys(({ userId }) => ({ pk: key("USER", userId), sk: key("PROFILE") }))
+  .identity(["userId"])
+  .accessPatterns(() => ({}));
+
+describe("connect/transact/update guardrails", () => {
+  it("rejects non-compiled entities and table mismatches", () => {
+    const adapter = createMemoryAdapter();
+    expect(() =>
+      connect(Table, {
+        adapter,
+        entities: { Broken: { runtime: {} } as never },
+      }),
+    ).toThrow(ConfigurationError);
+
+    expect(() => connect(Table, { adapter, entities: { UserOtherTable } })).toThrow(
+      /different table reference/,
+    );
+  });
+
+  it("rejects unknown read bundle and unknown recipe", async () => {
+    const db = connect(Table, { adapter: createMemoryAdapter(), entities: { User } });
+    await expect(db.read.run("missing", {})).rejects.toThrow(ValidationError);
+    await expect(db.recipes.run("missing", {})).rejects.toThrow(ValidationError);
+  });
+
+  it("enforces read bundle max depth and fanOut cap", async () => {
+    const db = connect(Table, {
+      adapter: createMemoryAdapter(),
+      entities: { User },
+      readBundles: (b) =>
+        b.bundle("users", (x) => x.rootPattern("users", "User", "scanAll", () => ({})), {
+          maxDepth: 2,
+        }),
+    });
+
+    await expect(db.read.run("users", { userId: "usr_1" as never })).rejects.toThrow(
+      /Only one-hop bundles/,
+    );
+    await db.User.create({ userId: "usr_1" as never, email: "u1@example.com" });
+    await expect(
+      db.read.run("users", { userId: "usr_1" as never }, { maxDepth: 1, fanOutCap: 0 }),
+    ).rejects.toThrow(/exceeded cap 0/);
+  });
+
+  it("supports lifecycle archive mark disposition", async () => {
+    const db = connect(Table, { adapter: createMemoryAdapter(), entities: { User } });
+    await db.User.create({ userId: "usr_arc" as never, email: "arc@example.com" });
+
+    const labels = await db.lifecycle.archive({
+      sourceEntity: User,
+      sourceKey: { userId: "usr_arc" as never },
+      archiveEntity: User,
+      archiveItem: { userId: "usr_arc_archive" as never, email: "arc+archive@example.com" },
+      sourceDisposition: "mark",
+      markFields: { status: "archived" },
+    });
+
+    expect(labels.archivePut?.operation).toBe("Put");
+    expect(labels.archiveSourceMark?.operation).toBe("Update");
+  });
+
+  it("rejects no-op updates, unknown path roots, and empty set operations", async () => {
+    const db = connect(Table, { adapter: createMemoryAdapter(), entities: { User } });
+    await db.User.create({ userId: "usr_upd" as never, email: "upd@example.com" });
+
+    await expect(db.User.update({ userId: "usr_upd" as never }).go()).rejects.toThrow(
+      /Update has no SET, ADD, or REMOVE/,
+    );
+    expect(() => db.User.update({ userId: "usr_upd" as never }).setPath("missing.path", 1)).toThrow(
+      ValidationError,
+    );
+    expect(() =>
+      db.User.update({ userId: "usr_upd" as never }).setAdd("status", new Set()),
+    ).toThrow(/Empty set is not allowed/);
+  });
+});

--- a/packages/core/test/table-defineTable-validation.test.ts
+++ b/packages/core/test/table-defineTable-validation.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { defineTable } from "../src/table.js";
+
+describe("defineTable local index validation", () => {
+  it("rejects more than five local secondary indexes", () => {
+    expect(() =>
+      defineTable({
+        name: "too_many_lsi",
+        partitionKey: "pk",
+        sortKey: "sk",
+        localIndexes: {
+          L1: { partitionKey: "pk", sortKey: "l1" },
+          L2: { partitionKey: "pk", sortKey: "l2" },
+          L3: { partitionKey: "pk", sortKey: "l3" },
+          L4: { partitionKey: "pk", sortKey: "l4" },
+          L5: { partitionKey: "pk", sortKey: "l5" },
+          L6: { partitionKey: "pk", sortKey: "l6" },
+        },
+      }),
+    ).toThrow(/at most 5 local secondary indexes/);
+  });
+
+  it("rejects local indexes without base sort key", () => {
+    expect(() =>
+      defineTable({
+        name: "missing_base_sort",
+        partitionKey: "pk",
+        localIndexes: {
+          L1: { partitionKey: "pk", sortKey: "l1" },
+        },
+      }),
+    ).toThrow(/localIndexes require a base-table sortKey/);
+  });
+
+  it("validates INCLUDE projection nonKeyAttributes rules", () => {
+    expect(() =>
+      defineTable({
+        name: "include_without_attrs",
+        partitionKey: "pk",
+        sortKey: "sk",
+        localIndexes: {
+          L1: { partitionKey: "pk", sortKey: "l1", projectionType: "INCLUDE" },
+        },
+      }),
+    ).toThrow(/nonKeyAttributes is required/);
+
+    expect(() =>
+      defineTable({
+        name: "all_with_attrs",
+        partitionKey: "pk",
+        sortKey: "sk",
+        localIndexes: {
+          L1: {
+            partitionKey: "pk",
+            sortKey: "l1",
+            projectionType: "ALL",
+            nonKeyAttributes: ["a"],
+          },
+        },
+      }),
+    ).toThrow(/only valid with projectionType INCLUDE/);
+  });
+
+  it("accepts a valid local index shape", () => {
+    const table = defineTable({
+      name: "valid_lsi",
+      partitionKey: "pk",
+      sortKey: "sk",
+      localIndexes: {
+        L1: {
+          partitionKey: "pk",
+          sortKey: "l1",
+          projectionType: "INCLUDE",
+          nonKeyAttributes: ["status"],
+        },
+      },
+    });
+    expect(table.localIndexes?.L1?.sortKey).toBe("l1");
+  });
+});

--- a/packages/core/test/transact-guards-and-errors.test.ts
+++ b/packages/core/test/transact-guards-and-errors.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  IdempotentParameterMismatchError,
+  TransactionCanceledError,
+  ValidationError,
+  connect,
+  defineTable,
+  entity,
+  id,
+  key,
+  string,
+} from "../src/index.js";
+import type { DynamoAdapter } from "../src/adapter.js";
+import { createMemoryAdapter } from "./mock-adapter.js";
+
+const T = defineTable({ name: "tx_guard_t", partitionKey: "pk", sortKey: "sk" });
+const E = entity("TxEntity", {
+  id: id("e").required(),
+  name: string().required(),
+})
+  .inTable(T)
+  .keys(({ id }) => ({ pk: key("E", id), sk: key("ROW") }))
+  .identity(["id"])
+  .accessPatterns(() => ({}));
+
+describe("transact guards and error mapping", () => {
+  it("rejects empty write participants", async () => {
+    const db = connect(T, { adapter: createMemoryAdapter(), entities: { E } });
+    await expect(db.tx.write(async () => {})).rejects.toThrow(ValidationError);
+  });
+
+  it("maps transaction canceled errors with reasons", async () => {
+    const base = createMemoryAdapter();
+    const adapter: DynamoAdapter = {
+      ...base,
+      transactWriteItems: async () => {
+        throw {
+          name: "TransactionCanceledException",
+          CancellationReasons: [{ Code: "ConditionalCheckFailed", Message: "failed condition" }],
+        };
+      },
+    };
+    const db = connect(T, { adapter, entities: { E } });
+    await expect(
+      db.tx.write(async (w) => {
+        w.put(E, { id: "e1" as never, name: "n1" });
+      }),
+    ).rejects.toBeInstanceOf(TransactionCanceledError);
+  });
+
+  it("maps idempotent token mismatch errors", async () => {
+    const base = createMemoryAdapter();
+    const adapter: DynamoAdapter = {
+      ...base,
+      transactWriteItems: async () => {
+        throw { __type: "IdempotentParameterMismatchException" };
+      },
+    };
+    const db = connect(T, { adapter, entities: { E } });
+    await expect(
+      db.tx.write(async (w) => {
+        w.put(E, { id: "e2" as never, name: "n2" });
+      }),
+    ).rejects.toBeInstanceOf(IdempotentParameterMismatchError);
+  });
+});

--- a/packages/streams/test/decode-branches.test.ts
+++ b/packages/streams/test/decode-branches.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import type { DynamoDBRecord } from "../src/index.js";
+import { decodeStreamRecord } from "../src/index.js";
+
+function record(base: Partial<DynamoDBRecord>): DynamoDBRecord {
+  return {
+    eventID: "1",
+    eventName: "MODIFY",
+    eventVersion: "1.1",
+    eventSource: "aws:dynamodb",
+    awsRegion: "us-east-1",
+    eventSourceARN: "arn:aws:dynamodb:us-east-1:123:table/t/stream/x",
+    dynamodb: {},
+    ...base,
+  } as DynamoDBRecord;
+}
+
+describe("decode stream branches", () => {
+  it("accepts default required view type NEW_AND_OLD_IMAGES", () => {
+    const decoded = decodeStreamRecord(
+      record({
+        eventName: "MODIFY",
+        dynamodb: {
+          StreamViewType: "NEW_AND_OLD_IMAGES",
+          NewImage: { entity: { S: "User" }, userId: { S: "u1" } },
+          OldImage: { entity: { S: "User" }, userId: { S: "u1_old" } },
+          Keys: { pk: { S: "USER#u1" }, sk: { S: "PROFILE" } },
+        },
+      }),
+      { decoders: { User: (v) => v } },
+    );
+    expect(decoded.keys).toMatchObject({ pk: "USER#u1", sk: "PROFILE" });
+    expect(decoded.entityName).toBe("User");
+  });
+
+  it("allows any required view type bypass", () => {
+    const decoded = decodeStreamRecord(
+      record({
+        eventName: "INSERT",
+        dynamodb: {
+          StreamViewType: "KEYS_ONLY",
+          Keys: { pk: { S: "USER#u1" }, sk: { S: "PROFILE" } },
+        },
+      }),
+      { decoders: {}, requiredViewType: "any", unknownEntityMode: "tolerant" },
+    );
+    expect(decoded.eventName).toBe("INSERT");
+    expect(decoded.newItem).toBeUndefined();
+  });
+
+  it("supports custom discriminator and decoder transform", () => {
+    const decoded = decodeStreamRecord(
+      record({
+        eventName: "INSERT",
+        dynamodb: {
+          StreamViewType: "NEW_IMAGE",
+          NewImage: {
+            kind: { S: "Invoice" },
+            id: { S: "inv_1" },
+          },
+        },
+      }),
+      {
+        decoders: {
+          Invoice: (item) => ({ ...item, tagged: true }),
+        },
+        discriminatorAttr: "kind",
+        requiredViewType: ["NEW_IMAGE"],
+      },
+    );
+    expect(decoded.entityName).toBe("Invoice");
+    expect(decoded.newItem).toMatchObject({ id: "inv_1", tagged: true });
+  });
+
+  it("supports tolerant missing discriminator branch", () => {
+    const decoded = decodeStreamRecord(
+      record({
+        eventName: "INSERT",
+        dynamodb: {
+          StreamViewType: "NEW_IMAGE",
+          NewImage: { id: { S: "no_entity" } },
+        },
+      }),
+      {
+        decoders: {},
+        unknownEntityMode: "tolerant",
+        requiredViewType: ["NEW_IMAGE"],
+      },
+    );
+    expect(decoded.entityName).toBeUndefined();
+    expect(decoded.newItem).toMatchObject({ id: "no_entity" });
+  });
+});

--- a/packages/streams/test/handler-routing.test.ts
+++ b/packages/streams/test/handler-routing.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { DynamoDBRecord, DynamoDBStreamEvent } from "../src/index.js";
+import { handleStreamByEntity } from "../src/index.js";
+
+function record(base: Partial<DynamoDBRecord>): DynamoDBRecord {
+  return {
+    eventID: "1",
+    eventName: "MODIFY",
+    eventVersion: "1.1",
+    eventSource: "aws:dynamodb",
+    awsRegion: "us-east-1",
+    eventSourceARN: "arn:aws:dynamodb:us-east-1:123:table/t/stream/x",
+    dynamodb: {},
+    ...base,
+  } as DynamoDBRecord;
+}
+
+describe("handler routing", () => {
+  it("no-ops when handler for event is not registered", async () => {
+    const seen: string[] = [];
+    const event: DynamoDBStreamEvent = {
+      Records: [
+        record({
+          eventName: "MODIFY",
+          dynamodb: {
+            StreamViewType: "NEW_IMAGE",
+            NewImage: { entity: { S: "User" }, userId: { S: "u1" } },
+          },
+        }),
+      ],
+    };
+
+    await handleStreamByEntity(event, {
+      decoders: { User: (item) => item },
+      requiredViewType: ["NEW_IMAGE"],
+      handlers: {
+        INSERT: async () => {
+          seen.push("insert");
+        },
+      },
+    });
+
+    expect(seen).toEqual([]);
+  });
+
+  it("preserves processing order and propagates handler errors", async () => {
+    const seen: string[] = [];
+    const event: DynamoDBStreamEvent = {
+      Records: [
+        record({
+          eventName: "INSERT",
+          dynamodb: {
+            StreamViewType: "NEW_IMAGE",
+            NewImage: { entity: { S: "User" }, userId: { S: "u1" } },
+          },
+        }),
+        record({
+          eventName: "INSERT",
+          dynamodb: {
+            StreamViewType: "NEW_IMAGE",
+            NewImage: { entity: { S: "User" }, userId: { S: "u2" } },
+          },
+        }),
+      ],
+    };
+
+    await expect(
+      handleStreamByEntity(event, {
+        decoders: { User: (item) => item },
+        requiredViewType: ["NEW_IMAGE"],
+        handlers: {
+          INSERT: async (evt) => {
+            const id = (evt.newItem as { userId?: string }).userId ?? "none";
+            seen.push(id);
+            if (id === "u2") throw new Error("boom");
+          },
+        },
+      }),
+    ).rejects.toThrow(/boom/);
+
+    expect(seen).toEqual(["u1", "u2"]);
+  });
+});

--- a/packages/streams/test/ttl-and-errors.test.ts
+++ b/packages/streams/test/ttl-and-errors.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import type { DynamoDBRecord } from "../src/index.js";
+import { decodeStreamRecord, isTtlRemove } from "../src/index.js";
+
+function record(base: Partial<DynamoDBRecord>): DynamoDBRecord {
+  return {
+    eventID: "1",
+    eventName: "REMOVE",
+    eventVersion: "1.1",
+    eventSource: "aws:dynamodb",
+    awsRegion: "us-east-1",
+    eventSourceARN: "arn:aws:dynamodb:us-east-1:123:table/t/stream/x",
+    dynamodb: {},
+    ...base,
+  } as DynamoDBRecord;
+}
+
+describe("ttl and decode error branches", () => {
+  it("returns false for non-ttl remove cases", () => {
+    expect(isTtlRemove(record({ eventName: "INSERT" }))).toBe(false);
+    expect(
+      isTtlRemove(
+        record({
+          userIdentity: { type: "Service", principalId: "other.amazonaws.com" },
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isTtlRemove(
+        record({
+          userIdentity: { type: "AssumedRole", principalId: "dynamodb.amazonaws.com" },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("throws in strict mode when discriminator is missing", () => {
+    expect(() =>
+      decodeStreamRecord(
+        record({
+          eventName: "INSERT",
+          dynamodb: {
+            StreamViewType: "NEW_IMAGE",
+            NewImage: { userId: { S: "u1" } },
+          },
+        }),
+        { decoders: {}, requiredViewType: ["NEW_IMAGE"], unknownEntityMode: "strict" },
+      ),
+    ).toThrow(/Missing discriminator/);
+  });
+
+  it("returns metadata fields from the original record", () => {
+    const decoded = decodeStreamRecord(
+      record({
+        eventName: "REMOVE",
+        eventSource: "aws:dynamodb",
+        userIdentity: { type: "Service", principalId: "dynamodb.amazonaws.com" },
+        dynamodb: {
+          StreamViewType: "KEYS_ONLY",
+          Keys: { pk: { S: "USER#1" }, sk: { S: "PROFILE" } },
+        },
+      }),
+      { decoders: {}, requiredViewType: "any", unknownEntityMode: "tolerant" },
+    );
+
+    expect(decoded.source).toBe("aws:dynamodb");
+    expect(decoded.userIdentityType).toBe("Service");
+    expect(decoded.userIdentityPrincipalId).toBe("dynamodb.amazonaws.com");
+    expect(decoded.keys).toMatchObject({ pk: "USER#1", sk: "PROFILE" });
+  });
+});


### PR DESCRIPTION
## Summary
- add focused core coverage tests for connect/transact/update guardrails, table LSI validation, and AWS error classifiers
- expand aws-sdk-v3 adapter unit coverage for normalization/fallback branches (query/scan/update/batchGet/transactGet/return-values)
- split streams coverage hardening into decode, handler routing, and ttl/error branch suites for stricter behavioral confidence

## Test plan
- [x] pnpm --filter @patternmeshjs/core test
- [x] pnpm --filter @patternmeshjs/aws-sdk-v3 test
- [x] pnpm --filter @patternmeshjs/streams test
- [x] pnpm --filter @patternmeshjs/core test:coverage
- [x] pnpm --filter @patternmeshjs/aws-sdk-v3 test:coverage
- [x] pnpm --filter @patternmeshjs/streams test:coverage
- [x] DYNAMODB_ENDPOINT=http://localhost:8000 pnpm test:coverage

Made with [Cursor](https://cursor.com)